### PR TITLE
Fix issue with asVersion not setting properly

### DIFF
--- a/src/ContextActivities.php
+++ b/src/ContextActivities.php
@@ -62,7 +62,7 @@ class ContextActivities implements VersionableInterface
         foreach (self::$directProps as $k) {
             $inner = $this->$k;
             if (isset($inner) && count($inner) > 0) {
-                $result = $result || array();
+                $result = $result ?: array();
 
                 $result[$k] = array();
 


### PR DESCRIPTION
When looping through multiple `$directProps` values, `$result` will not be set correctly after the first pass.

Potential fix for issue #8
