### PR TITLE
Add response getter/setter to Result

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -68,6 +68,8 @@ class Result implements VersionableInterface
     public function getCompletion() { return $this->completion; }
     public function setDuration($value) { $this->duration = $value; return $this; }
     public function getDuration() { return $this->duration; }
+    public function setResponse($value) { $this->response = $value; return $this; }
+    public function getResponse() { return $this->response; }
 
     public function setExtensions($value) {
         if (! $value instanceof Extensions) {


### PR DESCRIPTION
The `$response` value getter/setter was omitted making it impossible to set the response on a result.
