### PR TITLE
Simplify asVersion()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ tmp/
 
 # wild
 todo.md
+
+# eclipse project files
+.buildpath
+.project
+.settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ php:
   - 5.5
   - 5.4
   - hhvm
-before_script: cp tests/Config.php.travis-ci tests/Config.php
+before_script:
+  - cp tests/Config.php.travis-ci tests/Config.php
+  - composer install --dev

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Requires PHP 5.4 or later. (If you must run something older you should look at t
 TinCanPHP is available via [Composer](http://getcomposer.org).
 
 ```
-php composer.phar require rusticisoftware/tincan:~0.0
+php composer.phar require rusticisoftware/tincan:@stable
 ```
 
-With the package installed require the Composer autoloader:
+When not using Composer, require the autoloader:
 
 ```php
-require 'vendor/autoload.php';
+require 'path/to/TinCan/autoload.php';
 ```
 
 ### Testing

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,33 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+if (file_exists('vendor/autoload.php')) {
+    // prefer the composer autoloader
+    return require_once('vendor/autoload.php');
+}
+
+spl_autoload_register(function($className) {
+    $namespace = 'TinCan\\';
+    if (stripos($className, $namespace) === false) {
+        return;
+    }
+    $sourceDir = __DIR__ . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
+    $fileName  = str_replace([$namespace, '\\'], [$sourceDir, DIRECTORY_SEPARATOR], $className) . '.php';
+    if (is_readable($fileName)) {
+        include $fileName;
+    }
+});

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,16 @@
         "email": "support@tincanapi.com",
         "issues": "https://github.com/RusticiSoftware/TinCanPHP/issues"
     },
-    "require": {"php": "~5.4"},
+    "require": {
+        "php": "~5.4"
+    },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "2.*",
         "phpunit/phpunit": "@stable"
     },
     "autoload": {
-        "psr-4": {"TinCan\\": "src/"}
+        "psr-4": {
+            "TinCan\\": "src/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,12 @@
         "email": "support@tincanapi.com",
         "issues": "https://github.com/RusticiSoftware/TinCanPHP/issues"
     },
-    "require": {
-        "php": ">=5.4.0"
-    },
+    "require": {"php": "~5.4"},
     "require-dev": {
-        "phpdocumentor/phpdocumentor": "2.*"
+        "phpdocumentor/phpdocumentor": "2.*",
+        "phpunit/phpunit": "@stable"
     },
     "autoload": {
-        "psr-4": {
-            "TinCan\\": "src/"
-        }
+        "psr-4": {"TinCan\\": "src/"}
     }
 }

--- a/phpunit.php
+++ b/phpunit.php
@@ -2,47 +2,9 @@
 
 date_default_timezone_set('UTC');
 
+require_once('vendor/autoload.php');
 require_once('tests/Config.php');
 require_once('tests/Constants.php');
-
-require_once('src/LRSInterface.php');
-require_once('src/StatementTargetInterface.php');
-require_once('src/VersionableInterface.php');
-
-require_once('src/ArraySetterTrait.php');
-require_once('src/FromJSONTrait.php');
-require_once('src/AsVersionTrait.php');
-
-require_once('src/Map.php');
-require_once('src/LRSResponse.php');
-
-require_once('src/Util.php');
-require_once('src/Version.php');
-require_once('src/LanguageMap.php');
-require_once('src/Extensions.php');
-require_once('src/ActivityDefinition.php');
-require_once('src/Activity.php');
-require_once('src/AgentAccount.php');
-require_once('src/Agent.php');
-require_once('src/Group.php');
-require_once('src/Verb.php');
-require_once('src/ContextActivities.php');
-require_once('src/Context.php');
-require_once('src/Score.php');
-require_once('src/Result.php');
-require_once('src/StatementRef.php');
-require_once('src/StatementBase.php');
-require_once('src/SubStatement.php');
-require_once('src/Statement.php');
-
-require_once('src/StatementsResult.php');
-require_once('src/About.php');
-require_once('src/Document.php');
-require_once('src/ActivityProfile.php');
-require_once('src/AgentProfile.php');
-require_once('src/State.php');
-
-require_once('src/RemoteLRS.php');
 
 register_shutdown_function(
     function () {

--- a/phpunit.php
+++ b/phpunit.php
@@ -2,7 +2,7 @@
 
 date_default_timezone_set('UTC');
 
-require_once('vendor/autoload.php');
+require_once('autoload.php');
 require_once('tests/Config.php');
 require_once('tests/Constants.php');
 

--- a/sample/index.php
+++ b/sample/index.php
@@ -1,6 +1,6 @@
 <?php
 
-$loader = require '../vendor/autoload.php';
+$loader = require 'vendor/autoload.php';
 
 $lrs = new TinCan\RemoteLRS(
     'http://cloud.scorm.com/tc/public',

--- a/sample/index.php
+++ b/sample/index.php
@@ -1,6 +1,6 @@
 <?php
 
-$loader = require 'vendor/autoload.php';
+$loader = require '../vendor/autoload.php';
 
 $lrs = new TinCan\RemoteLRS(
     'http://cloud.scorm.com/tc/public',

--- a/src/About.php
+++ b/src/About.php
@@ -24,13 +24,6 @@ class About implements VersionableInterface
     protected $version;
     protected $extensions;
 
-    private static $directProps = array(
-        'version',
-    );
-    private static $versionedProps = array(
-        'extensions',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/Activity.php
+++ b/src/Activity.php
@@ -25,15 +25,6 @@ class Activity implements VersionableInterface, StatementTargetInterface
     protected $id;
     protected $definition;
 
-    private static $directProps = array(
-        'objectType',
-        'id',
-    );
-
-    private static $versionedProps = array(
-        'definition',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/ActivityDefinition.php
+++ b/src/ActivityDefinition.php
@@ -34,23 +34,6 @@ class ActivityDefinition implements VersionableInterface
     protected $target;
     protected $steps;
 
-    private static $directProps = array(
-        'type',
-        'moreInfo',
-        'interactionType',
-        'correctResponsesPattern',
-        'choices',
-        'scale',
-        'source',
-        'target',
-        'steps',
-    );
-    private static $versionedProps = array(
-        'name',
-        'description',
-        'extensions',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/AgentAccount.php
+++ b/src/AgentAccount.php
@@ -24,11 +24,6 @@ class AgentAccount implements VersionableInterface
     protected $name;
     protected $homePage;
 
-    private static $directProps = array(
-        'name',
-        'homePage',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/AsVersionTrait.php
+++ b/src/AsVersionTrait.php
@@ -17,31 +17,27 @@
 
 namespace TinCan;
 
+/**
+ * Basic implementation of the {@link VersionableInterface}
+ */
 trait AsVersionTrait
 {
-    public function asVersion($version) {
+    /**
+     * Collects defined object properties for a given version into an array
+     *
+     * @param  mixed $version
+     * @return array
+     */
+    public function asVersion($version)
+    {
         $result = array();
 
-        $klass = get_class($this);
-        if (property_exists($klass, 'directProps')) {
-            foreach ($klass::$directProps as $key) {
-                //print "AsVersionTrait::asVersion - " . get_class($this) . " - $key:" . $this->$key . "\n";
-
-                // TODO: should this be a prop name -> method map instead?
-                if (isset($this->$key) && ((! is_array($this->$key)) || (count($this->$key) > 0))) {
-                    $result[$key] = $this->$key;
-                }
+        foreach (get_object_vars($this) as $property => $value) {
+            if ($value instanceof VersionableInterface) {
+                $value = $value->asVersion($version);
             }
-        }
-        if (property_exists($klass, 'versionedProps')) {
-            foreach ($klass::$versionedProps as $key) {
-                if (isset($this->$key)) {
-                    //print "AsVersionTrait::asVersion: " . get_class($this) . " - $key\n";
-                    $versioned = $this->$key->asVersion($version);
-                    if (isset($versioned)) {
-                        $result[$key] = $versioned;
-                    }
-                }
+            if (isset($value)) {
+                $result[$property] = $value;
             }
         }
 

--- a/src/AsVersionTrait.php
+++ b/src/AsVersionTrait.php
@@ -30,8 +30,7 @@ trait AsVersionTrait
      * @param  mixed $version
      * @return array
      */
-    public function asVersion($version)
-    {
+    public function asVersion($version) {
         $result = array();
 
         foreach (get_object_vars($this) as $property => $value) {
@@ -57,8 +56,7 @@ trait AsVersionTrait
      * @param  mixed  $value
      * @throws DomainException
      */
-    final public function __set($property, $value)
-    {
+    final public function __set($property, $value) {
         throw new DomainException(__CLASS__ . ' is immutable');
     }
 }

--- a/src/AsVersionTrait.php
+++ b/src/AsVersionTrait.php
@@ -17,8 +17,10 @@
 
 namespace TinCan;
 
+use DomainException;
+
 /**
- * Basic implementation of the {@link VersionableInterface}
+ * Basic implementation of the VersionableInterface
  */
 trait AsVersionTrait
 {
@@ -46,5 +48,17 @@ trait AsVersionTrait
         }
 
         return $result;
+    }
+
+    /**
+     * Prevent external mutation
+     *
+     * @param  string $property
+     * @param  mixed  $value
+     * @throws DomainException
+     */
+    final public function __set($property, $value)
+    {
+        throw new DomainException(__CLASS__ . ' is immutable');
     }
 }

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -29,18 +29,6 @@ class Attachment implements VersionableInterface
     protected $sha2;
     protected $fileUrl;
 
-    private static $directProps = array(
-        'usageType',
-        'contentType',
-        'length',
-        'sha2',
-        'fileUrl'
-    );
-    private static $versionedProps = array(
-        'display',
-        'description',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/Context.php
+++ b/src/Context.php
@@ -17,6 +17,8 @@
 
 namespace TinCan;
 
+use InvalidArgumentException;
+
 class Context implements VersionableInterface
 {
     use ArraySetterTrait, FromJSONTrait, AsVersionTrait;
@@ -133,9 +135,6 @@ class Context implements VersionableInterface
         foreach ($result as $property => $value) {
             if (empty($value)) {
                 unset($result[$property]);
-            } elseif (is_array($value)) {
-                $this->_asVersion($value, $version);
-                $result[$property] = $value;
             } elseif ($value instanceof VersionableInterface) {
                 $result[$property] = $value->asVersion($version);
             }

--- a/src/Context.php
+++ b/src/Context.php
@@ -133,7 +133,7 @@ class Context implements VersionableInterface
     private function _asVersion(array &$result, $version)
     {
         foreach ($result as $property => $value) {
-            if (empty($value)) {
+            if (! isset($value)) {
                 unset($result[$property]);
             } elseif ($value instanceof VersionableInterface) {
                 $result[$property] = $value->asVersion($version);

--- a/src/Context.php
+++ b/src/Context.php
@@ -31,20 +31,6 @@ class Context implements VersionableInterface
     protected $statement;
     protected $extensions;
 
-    private static $directProps = array(
-        'registration',
-        'revision',
-        'platform',
-        'language',
-    );
-    private static $versionedProps = array(
-        'instructor',
-        'team',
-        'contextActivities',
-        'statement',
-        'extensions',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);
@@ -141,4 +127,18 @@ class Context implements VersionableInterface
         return $this;
     }
     public function getExtensions() { return $this->extensions; }
+
+    private function _asVersion(array &$result, $version)
+    {
+        foreach ($result as $property => $value) {
+            if (empty($value)) {
+                unset($result[$property]);
+            } elseif (is_array($value)) {
+                $this->_asVersion($value, $version);
+                $result[$property] = $value;
+            } elseif ($value instanceof VersionableInterface) {
+                $result[$property] = $value->asVersion($version);
+            }
+        }
+    }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -130,12 +130,12 @@ class Context implements VersionableInterface
     }
     public function getExtensions() { return $this->extensions; }
 
-    private function _asVersion(array &$result, $version)
-    {
+    private function _asVersion(array &$result, $version) {
         foreach ($result as $property => $value) {
             if (! isset($value)) {
                 unset($result[$property]);
-            } elseif ($value instanceof VersionableInterface) {
+            }
+            elseif ($value instanceof VersionableInterface) {
                 $result[$property] = $value->asVersion($version);
             }
         }

--- a/src/ContextActivities.php
+++ b/src/ContextActivities.php
@@ -19,19 +19,12 @@ namespace TinCan;
 
 class ContextActivities implements VersionableInterface
 {
-    use ArraySetterTrait, FromJSONTrait;
+    use ArraySetterTrait, FromJSONTrait, AsVersionTrait;
 
     protected $category = array();
     protected $parent = array();
     protected $grouping = array();
     protected $other = array();
-
-    private static $directProps = array(
-        'category',
-        'parent',
-        'grouping',
-        'other',
-    );
 
     public function __construct() {
         if (func_num_args() == 1) {
@@ -41,22 +34,18 @@ class ContextActivities implements VersionableInterface
         }
     }
 
-    public function asVersion($version) {
-        $result = null;
-
-        foreach (self::$directProps as $k) {
-            $inner = $this->$k;
-            if (isset($inner) && count($inner) > 0) {
-                $result = $result ?: array();
-
-                $result[$k] = array();
-
-                foreach ($inner as $act) {
-                    array_push($result[$k], $act->asVersion($version));
-                }
+    private function _asVersion(array &$result, $version)
+    {
+        foreach ($result as $property => $value) {
+            if (empty($value)) {
+                unset($result[$property]);
+            } elseif (is_array($value)) {
+                $this->_asVersion($value, $version);
+                $result[$property] = $value;
+            } elseif ($value instanceof VersionableInterface) {
+                $result[$property] = $value->asVersion($version);
             }
         }
-        return $result;
     }
 
     private function _listSetter($prop, $value) {

--- a/src/ContextActivities.php
+++ b/src/ContextActivities.php
@@ -34,15 +34,16 @@ class ContextActivities implements VersionableInterface
         }
     }
 
-    private function _asVersion(array &$result, $version)
-    {
+    private function _asVersion(array &$result, $version) {
         foreach ($result as $property => $value) {
             if (empty($value)) {
                 unset($result[$property]);
-            } elseif (is_array($value)) {
+            }
+            elseif (is_array($value)) {
                 $this->_asVersion($value, $version);
                 $result[$property] = $value;
-            } elseif ($value instanceof VersionableInterface) {
+            }
+            elseif ($value instanceof VersionableInterface) {
                 $result[$property] = $value->asVersion($version);
             }
         }

--- a/src/Result.php
+++ b/src/Result.php
@@ -28,17 +28,6 @@ class Result implements VersionableInterface
     protected $response;
     protected $extensions;
 
-    private static $directProps = array(
-        'success',
-        'completion',
-        'duration',
-        'response',
-    );
-    private static $versionedProps = array(
-        'score',
-        'extensions',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/Score.php
+++ b/src/Score.php
@@ -26,13 +26,6 @@ class Score implements VersionableInterface
     protected $min;
     protected $max;
 
-    private static $directProps = array(
-        'scaled',
-        'raw',
-        'min',
-        'max',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/src/Score.php
+++ b/src/Score.php
@@ -66,7 +66,6 @@ class Score implements VersionableInterface
      */
     protected $max;
 
-
     /**
      * Constructor
      *
@@ -75,8 +74,7 @@ class Score implements VersionableInterface
      * @param float       $aMax           the score maximum
      * @param float       $aScalingFactor the score scaling factor
      */
-    public function __construct($aRawValue = null, $aMin = null, $aMax = null, $aScalingFactor = null)
-    {
+    public function __construct($aRawValue = null, $aMin = null, $aMax = null, $aScalingFactor = null) {
         if (!is_array($aRawValue)) {
             $aRawValue = [
                 'raw'    => $aRawValue,
@@ -93,8 +91,7 @@ class Score implements VersionableInterface
      * @throws InvalidArgumentException
      * @return null
      */
-    public function validate($aValue)
-    {
+    public function validate($aValue) {
         if (!isset($this->min, $this->max)) {
             return;
         }
@@ -109,8 +106,7 @@ class Score implements VersionableInterface
      * @param  int $aPrecision a rounding precision integer
      * @return null|float
      */
-    public function getValue($aPrecision = self::DEFAULT_PRECISION)
-    {
+    public function getValue($aPrecision = self::DEFAULT_PRECISION) {
         if (!isset($this->raw)) {
             return null;
         }
@@ -125,8 +121,7 @@ class Score implements VersionableInterface
      * @throws InvalidArgumentException
      * @return self
      */
-    public function setScaled($value)
-    {
+    public function setScaled($value) {
         if ($value < static::SCALE_MIN || $value > static::SCALE_MAX) {
             throw new InvalidArgumentException(sprintf(
                 "Scale must be between %s and %s [%s]",
@@ -142,8 +137,7 @@ class Score implements VersionableInterface
     /**
      * @return null|float
      */
-    public function getScaled()
-    {
+    public function getScaled() {
         return $this->scaled;
     }
 
@@ -151,8 +145,7 @@ class Score implements VersionableInterface
      * @param  float $value
      * @return self
      */
-    public function setRaw($value)
-    {
+    public function setRaw($value) {
         $this->validate($value);
         $this->raw = (float) $value;
         return $this;
@@ -161,8 +154,7 @@ class Score implements VersionableInterface
     /**
      * @return null|float
      */
-    public function getRaw()
-    {
+    public function getRaw() {
         return $this->raw;
     }
 
@@ -171,8 +163,7 @@ class Score implements VersionableInterface
      * @throws InvalidArgumentException
      * @return self
      */
-    public function setMin($value)
-    {
+    public function setMin($value) {
         if (isset($this->max) && $value >= $this->max) {
             throw new InvalidArgumentException("Min must be less than max");
         }
@@ -183,8 +174,7 @@ class Score implements VersionableInterface
     /**
      * @return null|float
      */
-    public function getMin()
-    {
+    public function getMin() {
         return $this->min;
     }
 
@@ -193,8 +183,7 @@ class Score implements VersionableInterface
      * @throws InvalidArgumentException
      * @return self
      */
-    public function setMax($value)
-    {
+    public function setMax($value) {
         if (isset($this->min) && $value <= $this->min) {
             throw new InvalidArgumentException("Max must be greater than min");
         }
@@ -205,8 +194,7 @@ class Score implements VersionableInterface
     /**
      * @return null|float
      */
-    public function getMax()
-    {
+    public function getMax() {
         return $this->max;
     }
 }

--- a/src/Score.php
+++ b/src/Score.php
@@ -17,29 +17,196 @@
 
 namespace TinCan;
 
+use InvalidArgumentException;
+
+/**
+ * An optional field that represents the outcome of a graded Activity achieved
+ * by an Agent.
+ */
 class Score implements VersionableInterface
 {
     use ArraySetterTrait, FromJSONTrait, AsVersionTrait;
 
+    /**#@+
+     * Class constants
+     *
+     * @var int
+     */
+    const DEFAULT_PRECISION = 2;
+    const SCALE_MIN         = -1;
+    const SCALE_MAX         = 1;
+    /**#@- */
+
+    /**
+     * Decimal number between -1 and 1, inclusive
+     *
+     * @var float
+     */
     protected $scaled;
+
+    /**
+     * Decimal number between min and max (if present, otherwise unrestricted),
+     * inclusive
+     *
+     * @var float
+     */
     protected $raw;
+
+    /**
+     * Decimal number less than max (if present)
+     *
+     * @var float
+     */
     protected $min;
+
+    /**
+     * Decimal number greater than min (if present)
+     *
+     * @var float
+     */
     protected $max;
 
-    public function __construct() {
-        if (func_num_args() == 1) {
-            $arg = func_get_arg(0);
 
-            $this->_fromArray($arg);
+    /**
+     * Constructor
+     *
+     * @param float|array $aRawValue      the score value, may also be an array of properties
+     * @param float       $aMin           the score minimum
+     * @param float       $aMax           the score maximum
+     * @param float       $aScalingFactor the score scaling factor
+     */
+    public function __construct($aRawValue = null, $aMin = null, $aMax = null, $aScalingFactor = null)
+    {
+        if (!is_array($aRawValue)) {
+            $aRawValue = [
+                'raw'    => $aRawValue,
+                'min'    => $aMin,
+                'max'    => $aMax,
+                'scaled' => $aScalingFactor
+            ];
+        }
+        $this->_fromArray($aRawValue);
+    }
+
+    /**
+     * @param  float $aValue
+     * @throws InvalidArgumentException
+     * @return null
+     */
+    public function validate($aValue)
+    {
+        if (!isset($this->min, $this->max)) {
+            return;
+        }
+        if ($aValue < $this->min || $aValue > $this->max) {
+            throw new InvalidArgumentException(
+                sprintf("Value must be between %s and %s", $this->min, $this->max)
+            );
         }
     }
 
-    public function setScaled($value) { $this->scaled = $value; return $this; }
-    public function getScaled() { return $this->scaled; }
-    public function setRaw($value) { $this->raw = $value; return $this; }
-    public function getRaw() { return $this->raw; }
-    public function setMin($value) { $this->min = $value; return $this; }
-    public function getMin() { return $this->min; }
-    public function setMax($value) { $this->max = $value; return $this; }
-    public function getMax() { return $this->max; }
+    /**
+     * @param  int $aPrecision a rounding precision integer
+     * @return null|float
+     */
+    public function getValue($aPrecision = self::DEFAULT_PRECISION)
+    {
+        if (!isset($this->raw)) {
+            return null;
+        }
+        if (isset($this->scaled)) {
+            return round($this->raw * $this->scaled, $aPrecision);
+        }
+        return round($this->raw, $aPrecision);
+    }
+
+    /**
+     * @param  float $value
+     * @throws InvalidArgumentException
+     * @return self
+     */
+    public function setScaled($value)
+    {
+        if ($value < static::SCALE_MIN || $value > static::SCALE_MAX) {
+            throw new InvalidArgumentException(sprintf(
+                "Scale must be between %s and %s [%s]",
+                static::SCALE_MIN,
+                static::SCALE_MAX,
+                $value
+            ));
+        }
+        $this->scaled = (float) $value;
+        return $this;
+    }
+
+    /**
+     * @return null|float
+     */
+    public function getScaled()
+    {
+        return $this->scaled;
+    }
+
+    /**
+     * @param  float $value
+     * @return self
+     */
+    public function setRaw($value)
+    {
+        $this->validate($value);
+        $this->raw = (float) $value;
+        return $this;
+    }
+
+    /**
+     * @return null|float
+     */
+    public function getRaw()
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @param  float $value
+     * @throws InvalidArgumentException
+     * @return self
+     */
+    public function setMin($value)
+    {
+        if (isset($this->max) && $value >= $this->max) {
+            throw new InvalidArgumentException("Min must be less than max");
+        }
+        $this->min = (float) $value;
+        return $this;
+    }
+
+    /**
+     * @return null|float
+     */
+    public function getMin()
+    {
+        return $this->min;
+    }
+
+    /**
+     * @param  float $value
+     * @throws InvalidArgumentException
+     * @return self
+     */
+    public function setMax($value)
+    {
+        if (isset($this->min) && $value <= $this->min) {
+            throw new InvalidArgumentException("Max must be greater than min");
+        }
+        $this->max = (float) $value;
+        return $this;
+    }
+
+    /**
+     * @return null|float
+     */
+    public function getMax()
+    {
+        return $this->max;
+    }
 }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -34,20 +34,6 @@ class Statement extends StatementBase
     protected $version;
     protected $attachments;
 
-    protected static $directProps = array(
-        'id',
-        'timestamp',
-        'stored',
-        'version',
-    );
-    protected static $versionedProps = array(
-        'actor',
-        'verb',
-        'result',
-        'context',
-        'authority',
-    );
-
     public function __construct() {
         call_user_func_array('parent::__construct', func_get_args());
 
@@ -65,18 +51,6 @@ class Statement extends StatementBase
         }
         if (! isset($this->attachments)) {
             $this->setAttachments(array());
-        }
-    }
-
-    private function _asVersion(&$result, $version) {
-        $result = parent::_asVersion($result, $version);
-
-        if (count($this->attachments) > 0) {
-            $result['attachments'] = array();
-
-            foreach ($this->attachments as $k) {
-                array_push($result['attachments'], $k->asVersion($version));
-            }
         }
     }
 

--- a/src/StatementBase.php
+++ b/src/StatementBase.php
@@ -57,10 +57,12 @@ abstract class StatementBase implements VersionableInterface
         foreach ($result as $property => $value) {
             if ($value !== false && empty($value)) {
                 unset($result[$property]);
-            } elseif (is_array($value)) {
+            }
+            elseif (is_array($value)) {
                 $this->_asVersion($value, $version);
                 $result[$property] = $value;
-            } elseif ($value instanceof VersionableInterface) {
+            }
+            elseif ($value instanceof VersionableInterface) {
                 $result[$property] = $value->asVersion($version);
             }
         }

--- a/src/StatementBase.php
+++ b/src/StatementBase.php
@@ -36,16 +36,6 @@ abstract class StatementBase implements VersionableInterface
     //
     protected $timestamp;
 
-    protected static $directProps = array(
-        'timestamp',
-    );
-    protected static $versionedProps = array(
-        'actor',
-        'verb',
-        'result',
-        'context',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);
@@ -64,8 +54,19 @@ abstract class StatementBase implements VersionableInterface
     }
 
     private function _asVersion(&$result, $version) {
-        if (isset($this->target)) {
-            $result['object'] = $this->target->asVersion($version);
+        foreach ($result as $property => $value) {
+            if ($value !== false && empty($value)) {
+                unset($result[$property]);
+            } elseif (is_array($value)) {
+                $this->_asVersion($value, $version);
+                $result[$property] = $value;
+            } elseif ($value instanceof VersionableInterface) {
+                $result[$property] = $value->asVersion($version);
+            }
+        }
+        if (isset($result['target'])) {
+            $result['object'] = $result['target'];
+            unset($result['target']);
         }
     }
 

--- a/src/StatementRef.php
+++ b/src/StatementRef.php
@@ -17,6 +17,8 @@
 
 namespace TinCan;
 
+use InvalidArgumentException;
+
 class StatementRef implements VersionableInterface, StatementTargetInterface
 {
     use ArraySetterTrait, FromJSONTrait, AsVersionTrait;
@@ -24,11 +26,6 @@ class StatementRef implements VersionableInterface, StatementTargetInterface
     private $objectType = 'StatementRef';
 
     protected $id;
-
-    private static $directProps = array(
-        'objectType',
-        'id',
-    );
 
     public function __construct() {
         if (func_num_args() == 1) {

--- a/src/SubStatement.php
+++ b/src/SubStatement.php
@@ -19,12 +19,7 @@ namespace TinCan;
 
 class SubStatement extends StatementBase implements StatementTargetInterface
 {
-    private $objectType = 'SubStatement';
-
-    protected static $directProps = array(
-        'objectType',
-        'timestamp',
-    );
+    protected $objectType = 'SubStatement';
 
     public function getObjectType() { return $this->objectType; }
 }

--- a/src/Verb.php
+++ b/src/Verb.php
@@ -24,13 +24,6 @@ class Verb implements VersionableInterface
     protected $id;
     protected $display;
 
-    private static $directProps = array(
-        'id',
-    );
-    private static $versionedProps = array(
-        'display',
-    );
-
     public function __construct() {
         if (func_num_args() == 1) {
             $arg = func_get_arg(0);

--- a/tests/AboutTest.php
+++ b/tests/AboutTest.php
@@ -27,19 +27,19 @@ class AboutTest extends PHPUnit_Framework_TestCase {
         $this->assertAttributeNotEmpty('extensions', $obj, 'extenstions not empty');
     }
 
-    public function testUsesArraySetterTrait() {
-        $obj = new About();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\About'));
     }
 
-    public function testUsesFromJSONTrait() {
-        $obj = new About();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\About'));
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new About();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\About'));
     }
 
     public function testVersion() {

--- a/tests/AboutTest.php
+++ b/tests/AboutTest.php
@@ -27,18 +27,15 @@ class AboutTest extends PHPUnit_Framework_TestCase {
         $this->assertAttributeNotEmpty('extensions', $obj, 'extenstions not empty');
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\About'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\About'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\About'));
     }
 

--- a/tests/AboutTest.php
+++ b/tests/AboutTest.php
@@ -1,0 +1,67 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\About;
+
+class AboutTest extends PHPUnit_Framework_TestCase {
+    const VERSION_1 = '1.0.0';
+
+    public function testInstantiation() {
+        $obj = new About();
+        $this->assertInstanceOf('TinCan\About', $obj);
+        $this->assertAttributeEmpty('version', $obj, 'version empty');
+        $this->assertAttributeNotEmpty('extensions', $obj, 'extenstions not empty');
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new About();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new About();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new About();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
+    public function testVersion() {
+        $obj     = new About();
+        $version = [self::VERSION_1];
+        $this->assertSame($obj, $obj->setVersion($version));
+        $this->assertSame($version, $obj->getVersion());
+    }
+
+    public function testExtensionsWithArray() {
+        $obj = new About();
+        $this->assertSame($obj, $obj->setExtensions(['foo' => 'bar']));
+        $this->assertInstanceOf('TinCan\Extensions', $obj->getExtensions());
+        $this->assertFalse($obj->getExtensions()->isEmpty());
+    }
+
+    // TODO: need to loop versions
+    public function testAsVersion() {
+        $args      = ['version' => [self::VERSION_1]];
+        $obj       = new About($args);
+        $versioned = $obj->asVersion(self::VERSION_1);
+
+        $this->assertEquals($versioned, $args, "version only: 1.0.0");
+    }
+}

--- a/tests/ActivityDefinitionTest.php
+++ b/tests/ActivityDefinitionTest.php
@@ -49,19 +49,19 @@ class ActivityDefinitionTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait() {
-        $obj = new ActivityDefinition();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\ActivityDefinition'));
     }
 
-    public function testUsesFromJSONTrait() {
-        $obj = new ActivityDefinition();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\ActivityDefinition'));
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new ActivityDefinition();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\ActivityDefinition'));
     }
 
     // TODO: need more robust test (happy-path)

--- a/tests/ActivityDefinitionTest.php
+++ b/tests/ActivityDefinitionTest.php
@@ -49,18 +49,15 @@ class ActivityDefinitionTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\ActivityDefinition'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\ActivityDefinition'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\ActivityDefinition'));
     }
 

--- a/tests/ActivityDefinitionTest.php
+++ b/tests/ActivityDefinitionTest.php
@@ -1,0 +1,75 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\ActivityDefinition;
+
+class ActivityDefinitionTest extends PHPUnit_Framework_TestCase {
+    const NAME = 'testName';
+
+    private $emptyProperties = array(
+        'type',
+        'moreInfo',
+        'interactionType',
+        'correctResponsesPattern',
+        'choices',
+        'scale',
+        'source',
+        'target',
+        'steps',
+    );
+
+    private $nonEmptyProperties = array(
+        'name',
+        'description',
+        'extensions',
+    );
+
+    public function testInstantiation() {
+        $obj = new ActivityDefinition();
+        $this->assertInstanceOf('TinCan\ActivityDefinition', $obj);
+        foreach ($this->emptyProperties as $property) {
+            $this->assertAttributeEmpty($property, $obj, "$property empty");
+        }
+        foreach ($this->nonEmptyProperties as $property) {
+            $this->assertAttributeNotEmpty($property, $obj, "$property not empty");
+        }
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new ActivityDefinition();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new ActivityDefinition();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new ActivityDefinition();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
+    // TODO: need more robust test (happy-path)
+    public function testAsVersion() {
+        $args      = ['name' => [self::NAME]];
+        $obj       = new ActivityDefinition($args);
+        $versioned = $obj->asVersion('test');
+
+        $this->assertEquals($versioned, $args, "name only: test");
+    }
+}

--- a/tests/AgentAccountTest.php
+++ b/tests/AgentAccountTest.php
@@ -25,18 +25,15 @@ class AgentAccountTest extends PHPUnit_Framework_TestCase {
         $this->assertAttributeEmpty('name', $obj, 'name empty');
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\AgentAccount'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\AgentAccount'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\AgentAccount'));
     }
 

--- a/tests/AgentAccountTest.php
+++ b/tests/AgentAccountTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\AgentAccount;
+
+class AgentAccountTest extends PHPUnit_Framework_TestCase {
+    public function testInstantiation() {
+        $obj = new AgentAccount();
+        $this->assertInstanceOf('TinCan\AgentAccount', $obj);
+        $this->assertAttributeEmpty('homePage', $obj, 'homePage empty');
+        $this->assertAttributeEmpty('name', $obj, 'name empty');
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new AgentAccount();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new AgentAccount();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new AgentAccount();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
+    public function testName() {
+        $obj  = new AgentAccount();
+        $name = 'test';
+        $this->assertSame($obj, $obj->setName($name));
+        $this->assertSame($name, $obj->getName());
+    }
+
+    public function testHomePage() {
+        $obj      = new AgentAccount();
+        $homePage = 'http://tincanapi.com';
+        $this->assertSame($obj, $obj->setHomePage($homePage));
+        $this->assertSame($homePage, $obj->getHomePage());
+    }
+
+    public function testAsVersion() {
+        $args      = ['name' => 'test', 'homePage' => 'http://tincanapi.com'];
+        $obj       = new AgentAccount($args);
+        $versioned = $obj->asVersion('test');
+
+        $this->assertEquals($versioned, $args, "all properties: test");
+    }
+}

--- a/tests/AgentAccountTest.php
+++ b/tests/AgentAccountTest.php
@@ -25,19 +25,19 @@ class AgentAccountTest extends PHPUnit_Framework_TestCase {
         $this->assertAttributeEmpty('name', $obj, 'name empty');
     }
 
-    public function testUsesArraySetterTrait() {
-        $obj = new AgentAccount();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\AgentAccount'));
     }
 
-    public function testUsesFromJSONTrait() {
-        $obj = new AgentAccount();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\AgentAccount'));
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new AgentAccount();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\AgentAccount'));
     }
 
     public function testName() {

--- a/tests/AsVersionTraitTest.php
+++ b/tests/AsVersionTraitTest.php
@@ -1,0 +1,37 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+class AsVersionTraitTest extends PHPUnit_Framework_TestCase
+{
+    public function testTraitExists()
+    {
+        $this->assertTrue(trait_exists('TinCan\AsVersionTrait'));
+    }
+
+    public function testAsVersionReturnsArray()
+    {
+        $trait = $this->getMockForTrait('TinCan\AsVersionTrait');
+        $this->assertInternalType('array', $trait->asVersion('test'));
+    }
+
+    public function testMagicSetThrowsException()
+    {
+        $this->setExpectedException('DomainException');
+        $trait = $this->getMockForTrait('TinCan\AsVersionTrait');
+        $trait->foo = 'bar';
+    }
+}

--- a/tests/AsVersionTraitTest.php
+++ b/tests/AsVersionTraitTest.php
@@ -17,19 +17,16 @@
 
 class AsVersionTraitTest extends PHPUnit_Framework_TestCase
 {
-    public function testTraitExists()
-    {
+    public function testTraitExists() {
         $this->assertTrue(trait_exists('TinCan\AsVersionTrait'));
     }
 
-    public function testAsVersionReturnsArray()
-    {
+    public function testAsVersionReturnsArray() {
         $trait = $this->getMockForTrait('TinCan\AsVersionTrait');
         $this->assertInternalType('array', $trait->asVersion('test'));
     }
 
-    public function testMagicSetThrowsException()
-    {
+    public function testMagicSetThrowsException() {
         $this->setExpectedException('DomainException');
         $trait = $this->getMockForTrait('TinCan\AsVersionTrait');
         $trait->foo = 'bar';

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -1,0 +1,70 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\Attachment;
+
+class AttachmentTest extends PHPUnit_Framework_TestCase {
+    const DISPLAY = 'testDisplay';
+
+    private $emptyProperties = array(
+        'usageType',
+        'contentType',
+        'length',
+        'sha2',
+        'fileUrl',
+    );
+
+    private $nonEmptyProperties = array(
+        'display',
+        'description',
+    );
+
+    public function testInstantiation() {
+        $obj = new Attachment();
+        $this->assertInstanceOf('TinCan\Attachment', $obj);
+        foreach ($this->emptyProperties as $property) {
+            $this->assertAttributeEmpty($property, $obj, "$property empty");
+        }
+        foreach ($this->nonEmptyProperties as $property) {
+            $this->assertAttributeNotEmpty($property, $obj, "$property not empty");
+        }
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new Attachment();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new Attachment();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new Attachment();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
+    // TODO: need more robust test (happy-path)
+    public function testAsVersion() {
+        $args      = ['display' => [self::DISPLAY]];
+        $obj       = new Attachment($args);
+        $versioned = $obj->asVersion('test');
+
+        $this->assertEquals($versioned, $args, "display only: test");
+    }
+}

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -44,19 +44,19 @@ class AttachmentTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait() {
-        $obj = new Attachment();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Attachment'));
     }
 
-    public function testUsesFromJSONTrait() {
-        $obj = new Attachment();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Attachment'));
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new Attachment();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Attachment'));
     }
 
     // TODO: need more robust test (happy-path)

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -44,18 +44,15 @@ class AttachmentTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Attachment'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Attachment'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Attachment'));
     }
 

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -31,18 +31,15 @@ class ContextActivitiesTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\ContextActivities'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\ContextActivities'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\ContextActivities'));
     }
 

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -31,6 +31,11 @@ class ContextActivitiesTest extends PHPUnit_Framework_TestCase {
         }
     }
 
+    public function testUsesAsVersionTrait() {
+        $obj = new ContextActivities();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
     public function testFromJSONInstantiations() {
         $common_activity = new TinCan\Activity(self::$common_activity_cfg);
 
@@ -60,13 +65,16 @@ class ContextActivitiesTest extends PHPUnit_Framework_TestCase {
     // TODO: need to loop versions
     public function testAsVersion() {
         $obj = new ContextActivities();
+        $obj->setCategory(self::$common_activity_cfg);
         $versioned = $obj->asVersion('1.0.0');
 
-        //$this->assertEquals(
-            //[ 'objectType' => 'ContextActivities' ],
-            //$versioned,
-            //"empty: 1.0.0"
-        //);
+        $this->assertEquals(
+            ['category' => [
+                ['objectType' => 'Activity', 'id' => COMMON_ACTIVITY_ID]
+            ]],
+            $versioned,
+            "category only: 1.0.0"
+        );
     }
 
     public function testListSetters() {

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -31,9 +31,19 @@ class ContextActivitiesTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new ContextActivities();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\ContextActivities'));
+    }
+
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\ContextActivities'));
+    }
+
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\ContextActivities'));
     }
 
     public function testFromJSONInstantiations() {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -18,9 +18,42 @@
 use TinCan\Context;
 
 class ContextTest extends PHPUnit_Framework_TestCase {
+    private $emptyProperties = array(
+        'registration',
+        'revision',
+        'platform',
+        'language',
+    );
+
+    private $nonEmptyProperties = array(
+        'contextActivities',
+        'extensions',
+    );
+
     public function testInstantiation() {
         $obj = new Context();
         $this->assertInstanceOf('TinCan\Context', $obj);
+        foreach ($this->emptyProperties as $property) {
+            $this->assertAttributeEmpty($property, $obj, "$property empty");
+        }
+        foreach ($this->nonEmptyProperties as $property) {
+            $this->assertAttributeNotEmpty($property, $obj, "$property not empty");
+        }
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new Context();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new Context();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new Context();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
     }
 
     /*
@@ -33,16 +66,13 @@ class ContextTest extends PHPUnit_Framework_TestCase {
     }
     */
 
-    // TODO: need to loop versions
+    // TODO: need more robust test (happy-path)
     public function testAsVersion() {
-        $obj = new Context();
+        $args      = ['platform' => 'testPlatform'];
+        $obj       = new Context($args);
         $versioned = $obj->asVersion('1.0.0');
 
-        //$this->assertEquals(
-            //[ 'objectType' => 'Context' ],
-            //$versioned,
-            //"empty: 1.0.0"
-        //);
+        $this->assertEquals($versioned, $args, "platform only: 1.0.0");
     }
 
     public function testSetInstructor() {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -16,6 +16,7 @@
 */
 
 use TinCan\Context;
+use TinCan\Util;
 
 class ContextTest extends PHPUnit_Framework_TestCase {
     private $emptyProperties = array(
@@ -42,18 +43,15 @@ class ContextTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testUsesArraySetterTrait() {
-        $obj = new Context();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Context'));
     }
 
     public function testUsesFromJSONTrait() {
-        $obj = new Context();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Context'));
     }
 
     public function testUsesAsVersionTrait() {
-        $obj = new Context();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Context'));
     }
 
     /*
@@ -66,9 +64,35 @@ class ContextTest extends PHPUnit_Framework_TestCase {
     }
     */
 
-    // TODO: need more robust test (happy-path)
     public function testAsVersion() {
-        $args      = ['platform' => 'testPlatform'];
+        $args = [
+            'registration' => Util::getUUID(),
+            'instructor'   => [
+                'objectType' => 'Agent',
+                'name'       => 'test agent'
+            ],
+            'team' => [
+                'objectType' => 'Group',
+                'name'       => 'test group'
+            ],
+            'contextActivities' => [
+                'category' => [
+                    [
+                        'objectType' => 'Activity',
+                        'id'         => 'test category'
+                    ]
+                ]
+            ],
+            'revision'   => 'test revision',
+            'platform'   => 'test platform',
+            'language'   => 'test language',
+            'statement'  => [
+                'objectType' => 'StatementRef',
+                'id'         => Util::getUUID()
+            ],
+            'extensions' => ['test extension'],
+        ];
+
         $obj       = new Context($args);
         $versioned = $obj->asVersion('1.0.0');
 

--- a/tests/RemoteLRSTest.php
+++ b/tests/RemoteLRSTest.php
@@ -18,10 +18,10 @@
 use TinCan\RemoteLRS;
 
 class RemoteLRSTest extends PHPUnit_Framework_TestCase {
-    static private $endpoint = 'http://cloud.scorm.com/tc/3HYPTQLAI9/sandbox';
+    static private $endpoint = 'http://cloud.scorm.com/tc/public';
     static private $version  = '1.0.1';
-    static private $username = '';
-    static private $password = '';
+    static private $username = 'user';
+    static private $password = 'pass';
 
     public function testInstantiation() {
         $lrs = new RemoteLRS();

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -41,19 +41,19 @@ class ResultTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait() {
-        $obj = new Result();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Result'));
     }
 
-    public function testUsesFromJSONTrait() {
-        $obj = new Result();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Result'));
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new Result();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Result'));
     }
 
     // TODO: need more robust test (happy-path)

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,0 +1,67 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\Result;
+
+class ResultTest extends PHPUnit_Framework_TestCase {
+    private $emptyProperties = array(
+        'success',
+        'completion',
+        'duration',
+        'response',
+        'score',
+    );
+
+    private $nonEmptyProperties = array(
+        'extensions',
+    );
+
+    public function testInstantiation() {
+        $obj = new Result();
+        $this->assertInstanceOf('TinCan\Result', $obj);
+        foreach ($this->emptyProperties as $property) {
+            $this->assertAttributeEmpty($property, $obj, "$property empty");
+        }
+        foreach ($this->nonEmptyProperties as $property) {
+            $this->assertAttributeNotEmpty($property, $obj, "$property not empty");
+        }
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new Result();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new Result();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new Result();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
+    // TODO: need more robust test (happy-path)
+    public function testAsVersion() {
+        $args      = ['success' => true];
+        $obj       = new Result($args);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "success only: 1.0.0");
+    }
+}

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -41,18 +41,15 @@ class ResultTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Result'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Result'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Result'));
     }
 

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -25,7 +25,8 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         'max',
     );
 
-    public function testInstantiation() {
+    public function testInstantiation()
+    {
         $obj = new Score();
         $this->assertInstanceOf('TinCan\Score', $obj);
         foreach ($this->emptyProperties as $property) {
@@ -33,27 +34,116 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait() {
-        $obj = new Score();
-        $this->assertTrue(method_exists($obj, '_fromArray'));
+    public function testUsesArraySetterTrait()
+    {
+        $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Score'));
     }
 
-    public function testUsesFromJSONTrait() {
-        $obj = new Score();
-        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    public function testUsesFromJSONTrait()
+    {
+        $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Score'));
     }
 
-    public function testUsesAsVersionTrait() {
-        $obj = new Score();
-        $this->assertTrue(method_exists($obj, 'asVersion'));
+    public function testUsesAsVersionTrait()
+    {
+        $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Score'));
     }
 
-    // TODO: need more robust test (happy-path)
-    public function testAsVersion() {
-        $args      = ['raw' => 'test'];
+    public function testSetScaledThrowsException()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            sprintf('Scale must be between %s and %s [5]', Score::SCALE_MIN, Score::SCALE_MAX)
+        );
+        $score = new Score;
+        $score->setScaled(5);
+    }
+
+    public function testSetMinThrowsException()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Min must be less than max');
+        $score = new Score(['max' => 3.7]);
+        $score->setMin(8.1);
+    }
+
+    public function testSetMaxThrowsException()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Max must be greater than min');
+        $score = new Score(['min' => 5.3, 'max' => 3.7]);
+    }
+
+    public function testSetRawThrowsException()
+    {
+        $score = new Score(['min' => 1.5, 'max' => 4.3]);
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Value must be between 1.5 and 4.3'
+        );
+        $score->setRaw(1);
+    }
+
+    public function testGetRawReturnsFloat()
+    {
+        $score = new Score('1.5');
+        $this->assertInternalType('float', $score->getRaw());
+    }
+
+    public function testGetMinReturnsFloat()
+    {
+        $score = new Score(null, '1.5');
+        $this->assertInternalType('float', $score->getMin());
+    }
+
+    public function testGetMaxReturnsFloat()
+    {
+        $score = new Score(null, null, '1.5');
+        $this->assertInternalType('float', $score->getMax());
+    }
+
+    public function testGetScaledReturnsFloat()
+    {
+        $score = new Score(null, null, null, '0.5');
+        $this->assertInternalType('float', $score->getScaled());
+    }
+
+    public function testGetValueWithoutRawReturnsNull()
+    {
+        $score = new Score;
+        $this->assertNull($score->getValue());
+    }
+
+    public function testGetValueWithoutScaledReturnsRoundedRaw()
+    {
+        $raw   = 3.92013;
+        $score = new Score($raw);
+        $this->assertEquals(
+            round($raw, Score::DEFAULT_PRECISION),
+            $score->getValue()
+        );
+    }
+
+    public function testGetValueWithScaledReturnsScaledAndRoundedRaw()
+    {
+        $raw    = 3.92013;
+        $scaled = 0.8;
+        $score  = new Score($raw, null, null, $scaled);
+        $this->assertEquals(
+            round($raw * $scaled, Score::DEFAULT_PRECISION),
+            $score->getValue()
+        );
+    }
+
+    public function testAsVersion()
+    {
+        $args = [
+            'raw'    => '1.5',
+            'min'    => '1.0',
+            'max'    => '2.0',
+            'scaled' => '.95'
+        ];
         $obj       = new Score($args);
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals($versioned, $args, "raw only: 1.0.0");
+        $this->assertEquals($versioned, $args, "version: 1.0.0");
     }
 }

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -25,8 +25,7 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         'max',
     );
 
-    public function testInstantiation()
-    {
+    public function testInstantiation() {
         $obj = new Score();
         $this->assertInstanceOf('TinCan\Score', $obj);
         foreach ($this->emptyProperties as $property) {
@@ -34,23 +33,19 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testUsesArraySetterTrait()
-    {
+    public function testUsesArraySetterTrait() {
         $this->assertContains('TinCan\ArraySetterTrait', class_uses('TinCan\Score'));
     }
 
-    public function testUsesFromJSONTrait()
-    {
+    public function testUsesFromJSONTrait() {
         $this->assertContains('TinCan\FromJSONTrait', class_uses('TinCan\Score'));
     }
 
-    public function testUsesAsVersionTrait()
-    {
+    public function testUsesAsVersionTrait() {
         $this->assertContains('TinCan\AsVersionTrait', class_uses('TinCan\Score'));
     }
 
-    public function testSetScaledThrowsException()
-    {
+    public function testSetScaledThrowsException() {
         $this->setExpectedException(
             'InvalidArgumentException',
             sprintf('Scale must be between %s and %s [5]', Score::SCALE_MIN, Score::SCALE_MAX)
@@ -59,21 +54,18 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         $score->setScaled(5);
     }
 
-    public function testSetMinThrowsException()
-    {
+    public function testSetMinThrowsException() {
         $this->setExpectedException('InvalidArgumentException', 'Min must be less than max');
         $score = new Score(['max' => 3.7]);
         $score->setMin(8.1);
     }
 
-    public function testSetMaxThrowsException()
-    {
+    public function testSetMaxThrowsException() {
         $this->setExpectedException('InvalidArgumentException', 'Max must be greater than min');
         $score = new Score(['min' => 5.3, 'max' => 3.7]);
     }
 
-    public function testSetRawThrowsException()
-    {
+    public function testSetRawThrowsException() {
         $score = new Score(['min' => 1.5, 'max' => 4.3]);
         $this->setExpectedException(
             'InvalidArgumentException',
@@ -82,38 +74,32 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         $score->setRaw(1);
     }
 
-    public function testGetRawReturnsFloat()
-    {
+    public function testGetRawReturnsFloat() {
         $score = new Score('1.5');
         $this->assertInternalType('float', $score->getRaw());
     }
 
-    public function testGetMinReturnsFloat()
-    {
+    public function testGetMinReturnsFloat() {
         $score = new Score(null, '1.5');
         $this->assertInternalType('float', $score->getMin());
     }
 
-    public function testGetMaxReturnsFloat()
-    {
+    public function testGetMaxReturnsFloat() {
         $score = new Score(null, null, '1.5');
         $this->assertInternalType('float', $score->getMax());
     }
 
-    public function testGetScaledReturnsFloat()
-    {
+    public function testGetScaledReturnsFloat() {
         $score = new Score(null, null, null, '0.5');
         $this->assertInternalType('float', $score->getScaled());
     }
 
-    public function testGetValueWithoutRawReturnsNull()
-    {
+    public function testGetValueWithoutRawReturnsNull() {
         $score = new Score;
         $this->assertNull($score->getValue());
     }
 
-    public function testGetValueWithoutScaledReturnsRoundedRaw()
-    {
+    public function testGetValueWithoutScaledReturnsRoundedRaw() {
         $raw   = 3.92013;
         $score = new Score($raw);
         $this->assertEquals(
@@ -122,8 +108,7 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         );
     }
 
-    public function testGetValueWithScaledReturnsScaledAndRoundedRaw()
-    {
+    public function testGetValueWithScaledReturnsScaledAndRoundedRaw() {
         $raw    = 3.92013;
         $scaled = 0.8;
         $score  = new Score($raw, null, null, $scaled);
@@ -133,8 +118,7 @@ class ScoreTest extends PHPUnit_Framework_TestCase {
         );
     }
 
-    public function testAsVersion()
-    {
+    public function testAsVersion() {
         $args = [
             'raw'    => '1.5',
             'min'    => '1.0',

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\Score;
+
+class ScoreTest extends PHPUnit_Framework_TestCase {
+    private $emptyProperties = array(
+        'scaled',
+        'raw',
+        'min',
+        'max',
+    );
+
+    public function testInstantiation() {
+        $obj = new Score();
+        $this->assertInstanceOf('TinCan\Score', $obj);
+        foreach ($this->emptyProperties as $property) {
+            $this->assertAttributeEmpty($property, $obj, "$property empty");
+        }
+    }
+
+    public function testUsesArraySetterTrait() {
+        $obj = new Score();
+        $this->assertTrue(method_exists($obj, '_fromArray'));
+    }
+
+    public function testUsesFromJSONTrait() {
+        $obj = new Score();
+        $this->assertTrue(method_exists($obj, 'fromJSON'));
+    }
+
+    public function testUsesAsVersionTrait() {
+        $obj = new Score();
+        $this->assertTrue(method_exists($obj, 'asVersion'));
+    }
+
+    // TODO: need more robust test (happy-path)
+    public function testAsVersion() {
+        $args      = ['raw' => 'test'];
+        $obj       = new Score($args);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "raw only: 1.0.0");
+    }
+}

--- a/tests/StatementRefTest.php
+++ b/tests/StatementRefTest.php
@@ -26,22 +26,19 @@ class StatementRefTest extends PHPUnit_Framework_TestCase {
         $this->assertAttributeNotEmpty('objectType', $obj, 'objectType not empty');
     }
 
-    public function testGetObjectType()
-    {
+    public function testGetObjectType() {
         $obj = new StatementRef();
         $this->assertSame('StatementRef', $obj->getObjectType());
     }
 
-    public function testId()
-    {
+    public function testId() {
         $obj = new StatementRef();
         $id  = Util::getUUID();
         $this->assertSame($obj, $obj->setId($id));
         $this->assertSame($id, $obj->getId());
     }
 
-    public function testSetIdThrowsException()
-    {
+    public function testSetIdThrowsException() {
         $this->setExpectedException(
             'InvalidArgumentException',
             'arg1 must be a UUID'

--- a/tests/StatementRefTest.php
+++ b/tests/StatementRefTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+    Copyright 2014 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+use TinCan\StatementRef;
+use TinCan\Util;
+
+class StatementRefTest extends PHPUnit_Framework_TestCase {
+    public function testInstantiation() {
+        $obj = new StatementRef();
+        $this->assertInstanceOf('TinCan\StatementRef', $obj);
+        $this->assertAttributeEmpty('id', $obj, 'id empty');
+        $this->assertAttributeNotEmpty('objectType', $obj, 'objectType not empty');
+    }
+
+    public function testGetObjectType()
+    {
+        $obj = new StatementRef();
+        $this->assertSame('StatementRef', $obj->getObjectType());
+    }
+
+    public function testId()
+    {
+        $obj = new StatementRef();
+        $id  = Util::getUUID();
+        $this->assertSame($obj, $obj->setId($id));
+        $this->assertSame($id, $obj->getId());
+    }
+
+    public function testSetIdThrowsException()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'arg1 must be a UUID'
+        );
+        $obj = new StatementRef(['id' => 'foo']);
+    }
+
+    // TODO: need to loop versions
+    public function testAsVersion() {
+        $args = [
+            'objectType' => 'StatementRef',
+            'id' => Util::getUUID(),
+        ];
+        $obj = new StatementRef($args);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "version 1.0.0");
+    }
+}

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -142,10 +142,11 @@ class StatementTest extends PHPUnit_Framework_TestCase {
             'version' => '1.0.0',
             'attachments' => [
                 [
-                    'description' => [
-                        'en-US' => 'Attachment description'
-                    ],
-                    'length' => 0,
+                    'usageType'   => 'http://test',
+                    'display'     => ['en-US' => 'test display'],
+                    'contentType' => 'text/plain; charset=ascii',
+                    'length'      => 0,
+                    'sha2'        => hash('sha256', json_encode(['foo', 'bar']))
                 ]
             ]
         ];

--- a/tests/SubStatementTest.php
+++ b/tests/SubStatementTest.php
@@ -23,8 +23,7 @@ class SubStatementTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('TinCan\StatementBase', $obj);
     }
 
-    public function testGetObjectType()
-    {
+    public function testGetObjectType() {
         $obj = new SubStatement();
         $this->assertSame('SubStatement', $obj->getObjectType());
     }

--- a/tests/SubStatementTest.php
+++ b/tests/SubStatementTest.php
@@ -15,78 +15,24 @@
     limitations under the License.
 */
 
-use TinCan\Statement;
+use TinCan\SubStatement;
 
-class StatementTest extends PHPUnit_Framework_TestCase {
+class SubStatementTest extends PHPUnit_Framework_TestCase {
     public function testInstantiation() {
-        $obj = new Statement();
-        $this->assertInstanceOf('TinCan\Statement', $obj);
-        $this->assertAttributeEmpty('id', $obj, 'id empty');
-        $this->assertAttributeEmpty('actor', $obj, 'actor empty');
-        $this->assertAttributeEmpty('verb', $obj, 'verb empty');
-        $this->assertAttributeEmpty('target', $obj, 'target empty');
-        $this->assertAttributeEmpty('context', $obj, 'context empty');
-        $this->assertAttributeEmpty('result', $obj, 'result empty');
-        $this->assertAttributeEmpty('timestamp', $obj, 'timestamp empty');
-        $this->assertAttributeEmpty('stored', $obj, 'stored empty');
-        $this->assertAttributeEmpty('authority', $obj, 'authority empty');
-        $this->assertAttributeEmpty('version', $obj, 'version empty');
+        $obj = new SubStatement();
+        $this->assertInstanceOf('TinCan\StatementBase', $obj);
     }
 
-    public function testFromJSONInvalidNull() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Invalid JSON: ' . JSON_ERROR_NONE
-        );
-        $obj = Statement::fromJSON(null);
+    public function testGetObjectType()
+    {
+        $obj = new SubStatement();
+        $this->assertSame('SubStatement', $obj->getObjectType());
     }
-
-    public function testFromJSONInvalidEmptyString() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Invalid JSON: ' . JSON_ERROR_NONE
-        );
-        $obj = Statement::fromJSON('');
-    }
-
-    public function testFromJSONInvalidMalformed() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Invalid JSON: ' . JSON_ERROR_SYNTAX
-        );
-        $obj = Statement::fromJSON('{id:"some value"}');
-    }
-
-    public function testStamp() {
-        $obj = new Statement();
-        $obj->stamp();
-
-        $this->assertAttributeInternalType('string', 'timestamp', $obj, 'timestamp is string');
-        $this->assertRegExp(TinCan\Util::UUID_REGEX, $obj->getId(), 'id is UUId');
-    }
-
-    public function testSetId() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'arg1 must be a UUID "some invalid id"'
-        );
-
-        $obj = new Statement();
-        $obj->setId('some invalid id');
-    }
-
-    /*
-    // TODO: need to loop possible configs
-    public function testFromJSONInstantiations() {
-        $obj = Statement::fromJSON('{"id":"' . COMMON_MBOX . '"}');
-        $this->assertInstanceOf('TinCan\Statement', $obj);
-        $this->assertSame(COMMON_MBOX, $obj->getMbox(), 'mbox value');
-    }
-    */
 
     // TODO: need to loop versions
     public function testAsVersion() {
         $args = [
+            'objectType' => 'SubStatement',
             'actor' => [
                 'mbox' => COMMON_MBOX,
                 'objectType' => 'Agent',
@@ -139,21 +85,8 @@ class StatementTest extends PHPUnit_Framework_TestCase {
                     'scaled' => '.97'
                 ]
             ],
-            'version' => '1.0.0',
-            'attachments' => [
-                [
-                    'description' => [
-                        'en-US' => 'Attachment description'
-                    ],
-                    'length' => 0,
-                ]
-            ]
         ];
-        $obj = new Statement($args);
-
-        $obj->stamp();
-        $args['id']        = $obj->getId();
-        $args['timestamp'] = $obj->getTimestamp();
+        $obj = new SubStatement($args);
 
         $obj->getTarget()->getDefinition()->getDescription()->set('en-ES', 'Testo descriptiono');
         $args['object']['definition']['description'] = ['en-ES' => 'Testo descriptiono'];

--- a/tests/VerbTest.php
+++ b/tests/VerbTest.php
@@ -58,15 +58,15 @@ class VerbTest extends PHPUnit_Framework_TestCase {
 
     // TODO: need to loop versions
     public function testAsVersion() {
-        $obj = new Verb(
-            ['id' => COMMON_VERB_ID]
-        );
+        $args = [
+            'id' => COMMON_VERB_ID,
+            'display' => [
+                'en-US' => 'Test display'
+            ]
+        ];
+        $obj = new Verb($args);
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals(
-            $versioned,
-            [ 'id' => COMMON_VERB_ID ],
-            "id only: 1.0.0"
-        );
+        $this->assertEquals($versioned, $args, "version 1.0.0");
     }
 }


### PR DESCRIPTION
By leveraging `get_object_vars($this)`, the static property arrays are no longer necessary.  The catch is that all exportable properties in child classes must not be `private`, or must be handled in a custom `_asVersion()` method.

When tests were added or modified, only minimal happy-paths were taken.  More robust testing is still needed for complete coverage.  The exception is `StatementTest` which had it's `testAsVersion()` updated to actually test functionality.  It's now the most robust test of `AsVersionTrait::asVersion()` in the whole suite.

I welcome your feedback and look forward to helping out and working with you on this and your other libraries.