### PR TITLE
Fix for when zero (or too few) statements are returned but a more URL is returned

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -387,7 +387,7 @@ class RemoteLRS implements LRSInterface
             $response = $this->queryStatements($query, $isEnsureStatementReturnedCalled);
 
             if ($response->success) {
-                $statements = &$response->content->getStatements();
+                $statements = $response->content->getStatements();
                 $is_more_results = ($response->content->getMore() != null);
 
                 while (count($statements) <= $originalLimit && $is_more_results) {


### PR DESCRIPTION
_This pull request is similar to [pull request 95 just submitted to the TinCanJS library](https://github.com/RusticiSoftware/TinCanJS/pull/95)._

Some LRSes* are implemented in such a way that their index are optimized for certain combination of filters.

When statements are queried with filters that don't match the internal index of the LRS in question, the LRS will draw from a best-case internal index (matching some of the requested filters, but not all) and will filter out the statements against the additional filter not part of the index. In some cases, the returned result set has zero statements, and these LRSes also return a 'more' URL indicating more statements can be fetched. In some cases, just a few statements will be returned (fewer than expected, if a limit filter is set), and the 'more' URL is return to also indicate that more statement can be fetched.

This pull request contains a private method (`ensureStatementsReturned`) that detects this implementation idiosyncrasy and pages through the 'more' URLs until enough statements are returned. It's called from the `queryStatements` and `moreStatements` methods.

_* The LRS used in my tests was Saltbox's WaxLRS. I assumed that more LRSes address indexing efficiency by setting up indexes based on pre-determined filter combinations, which is why I'm proposing to modify the core libraries as opposed to writing a wrapper or implementing these checks at the application level._