### PR TITLE
Create a check for existence of key `ignore404` when sending requests

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -68,6 +68,8 @@ class Result implements VersionableInterface
     public function getCompletion() { return $this->completion; }
     public function setDuration($value) { $this->duration = $value; return $this; }
     public function getDuration() { return $this->duration; }
+    public function setResponse($value) { $this->response = $value; return $this; }
+    public function getResponse() { return $this->response; }
 
     public function setExtensions($value) {
         if (! $value instanceof Extensions) {


### PR DESCRIPTION
The option does not seem to always be sent (only handled via State API requests it seems), leading to an unhandled exception on LRS endpoints that 404.