### PR TITLE
Convert Version into a type-safe enum

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -17,19 +17,143 @@
 
 namespace TinCan;
 
-class Version
+use InvalidArgumentException;
+
+/**
+ * TinCan API Version
+ * 
+ * @internal implemented similar to a type-safe enum
+ * @package  TinCan
+ */
+final class Version
 {
-    private static $_supported = array(
-        "1.0.1",
-        "1.0.0"
-        //, "0.95"
-    );
-
-    public static function supported() {
-        return self::$_supported;
+    /**#@+
+     * Value constants
+     * 
+     * @var string
+     */
+    const V101 = "1.0.1";
+    const V100 = "1.0.0";
+    const V095 = "0.95";
+    /**#@- */
+    
+    /** @var array string => bool */
+    private static $supported = [
+        self::V101 => true,
+        self::V100 => true,
+        self::V095 => false
+    ];
+    
+    /** @var self[] */
+    private static $instances = [];
+    
+    /** @var string */
+    private $value;
+    
+    /**
+     * Constructor
+     * 
+     * @param  string $aValue a version value
+     * @throws InvalidArgumentException when the value is not recognized
+     */
+    private function __construct($aValue) {
+        if (!isset(static::$supported[$aValue])) {
+            throw new InvalidArgumentException("Invalid version [$aValue]");
+        }
+        $this->value = $aValue;
     }
-
+    
+    /**
+     * Does the value match?
+     * 
+     * @param  string $aValue a value to check
+     * @return bool
+     */
+    public function hasValue($aValue) {
+        return $this->value === (string) $aValue;
+    }
+    
+    /**
+     * Is the value contained in a list of versions?
+     * 
+     * @param  string[] $aValueList a list of values to check
+     * @return bool
+     */
+    public function hasAnyValue(array $aValueList) {
+        return in_array($this->value, $aValueList);
+    }
+    
+    /**
+     * Is this the latest version?
+     * 
+     * @return bool
+     */
+    public function isLatest() {
+        return $this->value === static::latest();
+    }
+    
+    /**
+     * Is this a supported version?
+     * 
+     * @return bool
+     */
+    public function isSupported() {
+        return static::$supported[$this->value];
+    }
+    
+    /**
+     * Convert the object to a string
+     * 
+     * @return string
+     */
+    public function __toString() {
+        return $this->value;
+    }
+    
+    /**
+     * Factory constructor
+     * 
+     * @example $version = Version::V101();
+     * @param   string $aValue    the called method as a version value
+     * @param   array  $arguments unused arguments passed to the method
+     * @return  self
+     */
+    public static function __callStatic($aValue, array $arguments = []) {
+        $aValue = trim(preg_replace("#v(\d)(95|\d)(\d)?#i", '$1.$2.$3', $aValue), ".");
+        if (!isset(static::$instances[$aValue])) {
+            static::$instances[$aValue] = new static($aValue);
+        }
+        return static::$instances[$aValue];
+    }
+    
+    /**
+     * Convert a string into a Version instance
+     * 
+     * @param  string $aValue a version value
+     * @return self
+     */
+    public static function fromString($aValue) {
+        $aValue = str_replace(".", "", $aValue);
+        return static::{"V$aValue"}();
+    }
+    
+    /**
+     * List all supported versions
+     * 
+     * @return string[]
+     */
+    public static function supported() {
+        return array_keys(array_filter(static::$supported, function($supported) {
+            return $supported === true;
+        }));
+    }
+    
+    /**
+     * Retrieve the most recent version
+     * 
+     * @return string
+     */
     public static function latest() {
-        return self::$_supported[0];
+        return array_keys(static::$supported)[0];
     }
 }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -15,24 +15,41 @@
     limitations under the License.
 */
 
-class VersionTest extends PHPUnit_Framework_TestCase {
-    public function testSupported() {
-        $result = TinCan\Version::supported();
+use TinCan\Version;
 
-        $this->assertEquals(
-            [
-                "1.0.1",
-                "1.0.0"
-                //, "0.95"
-            ],
-            $result,
-            "match supported"
-        );
+class VersionTest extends PHPUnit_Framework_TestCase {
+    public function testStaticFactoryReturnsInstance() {
+        $this->assertInstanceOf("TinCan\Version", Version::v101(), "factory returns instance");
+    }
+    
+    public function testToString() {
+        $this->assertInternalType("string", (string) Version::v101(), "object converts to string");
+    }
+    
+    public function testHasValueReturnsBool() {
+        $this->assertTrue(Version::v101()->hasValue(Version::V101), "object has correct value");
+    }
+    
+    public function testHasAnyValueReturnsBool() {
+        $this->assertFalse(Version::v101()->hasAnyValue([Version::V100, Version::V095]), "object does not have values");
+    }
+    
+    public function testIsSupportedReturnsBool() {
+        $this->assertTrue(Version::v100()->isSupported(), "1.0.0 should be supported");
+        $this->assertFalse(Version::v095()->isSupported(), "0.95 should not be supported");
+    }
+    
+    public function testIsLatestReturnsBool() {
+        $this->assertTrue(Version::v101()->isLatest(), "1.0.1 should be the latest version");
+        $this->assertFalse(Version::v095()->isLatest(), "0.95 should not be the latest version");
+    }
+    
+    public function testSupported() {
+        $result = Version::supported();
+        $this->assertNotContains(Version::V095, $result, "0.95 not included");
     }
 
     public function testLatest() {
-        $result = TinCan\Version::latest();
-
-        $this->assertSame("1.0.1", $result, "match latest");
+        $this->assertSame(Version::V101, Version::latest(), "match latest");
     }
 }


### PR DESCRIPTION
```php
use TinCan\Version;

$version = Version::v101();

assert($version->isLatest());
assert($version->isSupported());
assert($version->hasValue(Version::V101));
```
I've been digging through the other TinCan repos to better understand how the API is intended to be implemented.  Since PHP does not support the `enum` type without [an extension](http://php.net/manual/en/book.spl-types.php), I've used the `type-safe enum` pattern§ to better align `Version` with the other stacks.  It's not a `1:1` match, but it does improve stability by replacing version strings with immutable class constants and extends functionality by encapsulating version logic in a class object.  The trade-off is added complexity.  However, I've maintained BC with the existing methods.  While the new constants can be used to replace existing version strings, I would recommend leveraging the new functionality by adding a type-hint to the `asVersion()` method(s).
```php
public function asVersion(Version $aVersion);
```

> Note:  The `hhvm` build failed from what looks to be an invalid file path for the new cert.

> § Item 21: Replace enum constructs with classes, *Effective Java Programming Language Guide*, Joshua Bloch