### PR TITLE
Utils.timestamp fix (updated+tested)

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -67,12 +67,16 @@ class Util
     //
     // Based on code from
     // http://stackoverflow.com/a/4414060/1464957
-    //
-    // TODO: is this giving too much precision?
-    //
     public static function getTimestamp() {
-        $t = microtime(true);
-        $micro = sprintf("%06d", ($t - floor($t)) * 1000000);
-        return date('Y-m-d\TH:i:s.' . $micro . 'O', $t);
+        $time = microtime(true);
+        $microseconds = sprintf('%06d', ($time - floor($time)) * 1000000);
+        $millseconds = round($microseconds, -3)/1000;
+        $millsecondsStr = str_pad($millseconds, 3, '0', STR_PAD_LEFT);
+        $date = (new \DateTime())->format('c');
+
+        $position = strrpos($date, '+');
+        $date = substr($date,0,$position).'.'.$millsecondsStr.substr($date,$position);
+
+        return $date;
     }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -21,4 +21,15 @@ class UtilTest extends PHPUnit_Framework_TestCase {
 
         $this->assertRegExp(TinCan\Util::UUID_REGEX, $result);
     }
+
+    public function testGetTimestamp() {
+        $result = TinCan\Util::getTimestamp();
+
+        //
+        // this isn't intended to match all ISO8601 just *our* format of it, so it should
+        // catch regressions, at least more than will be accepted by an LRS which is really
+        // ultimately what we want in our tests
+        //
+        $this->assertRegExp('/\d\d\d\d-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d\d\d[-+]\d\d:\d\d/', $result);
+    }
 }


### PR DESCRIPTION
Replaces #37 to fix #22.