### PR TITLE
Adjust `asVersion` trait to handle arrays and empty values

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -46,10 +46,14 @@ class Agent implements VersionableInterface, StatementTargetInterface, Comparabl
         }
 
         //
-        // only one of these
+        // only one of these, note that if 'account' has been set
+        // but is returned empty then no IFI will be included
         //
         if (isset($this->account)) {
-            $result['account'] = $this->account->asVersion($version);
+            $versioned_acct = $this->account->asVersion($version);
+            if (! empty($versioned_acct)) {
+                $result['account'] = $versioned_acct;
+            }
         }
         elseif (isset($this->mbox_sha1sum)) {
             $result['mbox_sha1sum'] = $this->mbox_sha1sum;

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -94,7 +94,7 @@ class Agent implements VersionableInterface, StatementTargetInterface, Comparabl
 
             return array('success' => false, 'reason' => 'Comparison of this.mbox to signature.mbox_sha1sum failed: no match');
         }
-        else if (isset($fromSig->mbox) && isset($this->mbox_sha1sum)) {
+        elseif (isset($fromSig->mbox) && isset($this->mbox_sha1sum)) {
             if ($fromSig->getMbox_sha1sum() === $this->mbox_sha1sum) {
                 return array('success' => true, 'reason' => null);
             }

--- a/src/AsVersionTrait.php
+++ b/src/AsVersionTrait.php
@@ -46,7 +46,20 @@ trait AsVersionTrait
             if ($value instanceof VersionableInterface) {
                 $value = $value->asVersion($version);
             }
-            if (isset($value)) {
+            else if (is_array($value) && !empty($value)) {
+                $tmp_value = array();
+                foreach ($value as $element) {
+                    if ($element instanceof VersionableInterface) {
+                        array_push($tmp_value, $element->asVersion($version));
+                    }
+                    else {
+                        array_push($tmp_value, $element);
+                    }
+                }
+                $value = $tmp_value;
+            }
+
+            if (isset($value) && (!is_array($value) || !empty($value))) {
                 $result[$property] = $value;
             }
         }

--- a/src/Context.php
+++ b/src/Context.php
@@ -129,15 +129,4 @@ class Context implements VersionableInterface, ComparableInterface
         return $this;
     }
     public function getExtensions() { return $this->extensions; }
-
-    private function _asVersion(array &$result, $version) {
-        foreach ($result as $property => $value) {
-            if (! isset($value)) {
-                unset($result[$property]);
-            }
-            elseif ($value instanceof VersionableInterface) {
-                $result[$property] = $value->asVersion($version);
-            }
-        }
-    }
 }

--- a/src/ContextActivities.php
+++ b/src/ContextActivities.php
@@ -34,21 +34,6 @@ class ContextActivities implements VersionableInterface, ComparableInterface
         }
     }
 
-    private function _asVersion(array &$result, $version) {
-        foreach ($result as $property => $value) {
-            if (empty($value)) {
-                unset($result[$property]);
-            }
-            elseif (is_array($value)) {
-                $this->_asVersion($value, $version);
-                $result[$property] = $value;
-            }
-            elseif ($value instanceof VersionableInterface) {
-                $result[$property] = $value->asVersion($version);
-            }
-        }
-    }
-
     private function _listSetter($prop, $value) {
         if (is_array($value)) {
             if (isset($value['id'])) {

--- a/src/Result.php
+++ b/src/Result.php
@@ -40,6 +40,15 @@ class Result implements VersionableInterface, ComparableInterface
         }
     }
 
+    private function _asVersion(&$result, $version) {
+        //
+        // empty string is an invalid duration
+        //
+        if (isset($result['duration']) && $result['duration'] == '') {
+            unset($result['duration']);
+        }
+    }
+
     public function setScore($value) {
         if (! $value instanceof Score && is_array($value)) {
             $value = new Score($value);

--- a/src/StatementBase.php
+++ b/src/StatementBase.php
@@ -59,18 +59,6 @@ abstract class StatementBase implements VersionableInterface, ComparableInterfac
     }
 
     private function _asVersion(&$result, $version) {
-        foreach ($result as $property => $value) {
-            if ($value !== false && empty($value)) {
-                unset($result[$property]);
-            }
-            elseif (is_array($value)) {
-                $this->_asVersion($value, $version);
-                $result[$property] = $value;
-            }
-            elseif ($value instanceof VersionableInterface) {
-                $result[$property] = $value->asVersion($version);
-            }
-        }
         if (isset($result['target'])) {
             $result['object'] = $result['target'];
             unset($result['target']);

--- a/tests/ActivityDefinitionTest.php
+++ b/tests/ActivityDefinitionTest.php
@@ -65,10 +65,55 @@ class ActivityDefinitionTest extends \PHPUnit_Framework_TestCase {
 
     // TODO: need more robust test (happy-path)
     public function testAsVersion() {
-        $args      = ['name' => [self::NAME]];
-        $obj       = new ActivityDefinition($args);
-        $versioned = $obj->asVersion('test');
+        $args      = [
+            'name' => ['en' => self::NAME],
+            'extensions' => []
+        ];
+        $args['extensions'][COMMON_EXTENSION_ID_1] = 'test';
 
-        $this->assertEquals($versioned, $args, "name only: test");
+        $obj       = ActivityDefinition::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = ActivityDefinition::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmptyLanguageMap() {
+        $args      = ['name' => []];
+
+        $obj       = ActivityDefinition::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['name']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyExtensions() {
+        $args      = ['extensions' => []];
+
+        $obj       = ActivityDefinition::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['extensions']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyStringInLanguageMap() {
+        $args      = ['name' => ['en' => '']];
+
+        $obj       = ActivityDefinition::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
     }
 }

--- a/tests/ActivityTest.php
+++ b/tests/ActivityTest.php
@@ -75,16 +75,58 @@ class ActivityTest extends \PHPUnit_Framework_TestCase {
 
     // TODO: need to loop versions
     public function testAsVersion() {
-        $obj = new Activity(
-            array('id' => COMMON_ACTIVITY_ID)
-        );
+        $args = [
+            'id' => COMMON_ACTIVITY_ID,
+            'definition' => [
+                'name' => [
+                    'en' => 'test'
+                ]
+            ]
+        ];
+
+        $obj       = Activity::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals(
-            $versioned,
-            [ 'objectType' => 'Activity', 'id' => COMMON_ACTIVITY_ID ],
-            "id only: 1.0.0"
-        );
+        $args['objectType'] = 'Activity';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Activity::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Activity';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionIdOnly() {
+        $args = [ 'id' => COMMON_ACTIVITY_ID ];
+
+        $obj       = Activity::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Activity';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyDefinition() {
+        $args = [
+            'id' => COMMON_ACTIVITY_ID,
+            'definition' => []
+        ];
+
+        $obj       = Activity::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Activity';
+        unset($args['definition']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
     }
 
     public function testCompareWithSignature() {

--- a/tests/AgentAccountTest.php
+++ b/tests/AgentAccountTest.php
@@ -59,11 +59,36 @@ class AgentAccountTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testAsVersion() {
-        $args      = ['name' => COMMON_ACCT_NAME, 'homePage' => COMMON_ACCT_HOMEPAGE];
-        $obj       = new AgentAccount($args);
+        $args      = [
+            'name' => COMMON_ACCT_NAME,
+            'homePage' => COMMON_ACCT_HOMEPAGE
+        ];
+
+        $obj       = AgentAccount::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals($versioned, $args, "all properties: test");
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = AgentAccount::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmptyStrings() {
+        $args      = [
+            'name' => '',
+            'homePage' => ''
+        ];
+
+        $obj       = AgentAccount::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
     }
 
     public function testCompareWithSignature() {

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -65,17 +65,87 @@ class AgentTest extends \PHPUnit_Framework_TestCase {
     }
 
     // TODO: need to loop versions
-    public function testAsVersion() {
-        $obj = new Agent(
-            [ 'mbox' => COMMON_MBOX ]
-        );
+    public function testAsVersionMbox() {
+        $args      = [
+            'mbox' => COMMON_MBOX
+        ];
+
+        $obj       = Agent::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals(
-            [ 'objectType' => 'Agent', 'mbox' => COMMON_MBOX ],
-            $versioned,
-            "mbox only: 1.0.0"
-        );
+        $args['objectType'] = 'Agent';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionMboxSha1() {
+        $args      = [
+            'mbox_sha1sum' => COMMON_MBOX_SHA1
+        ];
+
+        $obj       = Agent::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Agent';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionAccount() {
+        $args      = [
+            'account' => [
+                'name' => COMMON_ACCT_NAME,
+                'homePage' => COMMON_ACCT_HOMEPAGE
+            ]
+        ];
+
+        $obj       = Agent::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Agent';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionAccountEmptyStrings() {
+        $args      = [
+            'account' => [
+                'name' => '',
+                'homePage' => ''
+            ]
+        ];
+
+        $obj       = Agent::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Agent';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyAccount() {
+        $args      = [
+            'account' => []
+        ];
+
+        $obj       = Agent::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Agent';
+        unset($args['account']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Agent::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Agent';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
     }
 
     public function testIsIdentified() {

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -120,6 +120,26 @@ class AttachmentTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Attachment::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmptyLanguageMap() {
+        $args      = ['display' => []];
+
+        $obj       = Attachment::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['display']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
     public function testCompareWithSignature() {
         $full = [
             'usageType'   => self::USAGE_TYPE,

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -75,18 +75,45 @@ class ContextActivitiesTest extends \PHPUnit_Framework_TestCase {
     }
 
     // TODO: need to loop versions
-    public function testAsVersion() {
-        $obj = new ContextActivities();
-        $obj->setCategory(self::$common_activity_cfg);
+    public function testAsVersionWithSingleList() {
+        $keys = ['category', 'parent', 'grouping', 'other'];
+        foreach ($keys as $k) {
+            $args      = [];
+            $args[$k]  = [ self::$common_activity_cfg ];
+
+            $obj       = ContextActivities::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+            $versioned = $obj->asVersion('1.0.0');
+
+            $args[$k][0]['objectType'] = 'Activity';
+
+            $this->assertEquals($versioned, $args, "serialized version matches original");
+
+            unset($args[$k][0]['objectType']);
+        }
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = ContextActivities::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals(
-            ['category' => [
-                ['objectType' => 'Activity', 'id' => COMMON_ACTIVITY_ID]
-            ]],
-            $versioned,
-            "category only: 1.0.0"
-        );
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionWithEmptyList() {
+        $keys = ['category', 'parent', 'grouping', 'other'];
+        foreach ($keys as $k) {
+            $args      = [];
+            $args[$k]  = [];
+
+            $obj       = ContextActivities::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+            $versioned = $obj->asVersion('1.0.0');
+
+            unset($args[$k]);
+
+            $this->assertEquals($versioned, $args, "serialized version matches corrected");
+        }
     }
 
     public function testListSetters() {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -77,18 +77,15 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
         $args = [
             'registration' => Util::getUUID(),
             'instructor'   => [
-                'objectType' => 'Agent',
-                'name'       => 'test agent'
+                'name' => 'test agent'
             ],
             'team' => [
-                'objectType' => 'Group',
-                'name'       => 'test group'
+                'name' => 'test group'
             ],
             'contextActivities' => [
                 'category' => [
                     [
-                        'objectType' => 'Activity',
-                        'id'         => 'test category'
+                        'id' => 'test category'
                     ]
                 ]
             ],
@@ -96,16 +93,47 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
             'platform'   => 'test platform',
             'language'   => 'test language',
             'statement'  => [
-                'objectType' => 'StatementRef',
-                'id'         => Util::getUUID()
+                'id' => Util::getUUID()
             ],
-            'extensions' => ['test extension'],
+            'extensions' => [],
         ];
+        $args['extensions'][COMMON_EXTENSION_ID_1] = "test";
 
-        $obj       = new Context($args);
+        $obj       = Context::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals($versioned, $args, "platform only: 1.0.0");
+        $args['instructor']['objectType'] = 'Agent';
+        $args['team']['objectType'] = 'Group';
+        $args['contextActivities']['category'][0]['objectType'] = 'Activity';
+        $args['statement']['objectType'] = 'StatementRef';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Context::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmptyLists() {
+        $args = [
+            'contextActivities' => [
+                'category' => []
+            ],
+            'extensions' => [],
+        ];
+
+        $obj       = Context::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['contextActivities']);
+        unset($args['extensions']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
     }
 
     public function testSetInstructor() {

--- a/tests/ExtensionsTest.php
+++ b/tests/ExtensionsTest.php
@@ -38,6 +38,15 @@ class ExtensionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($versioned, $args, "version: 1.0.0");
     }
 
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Extensions::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, null, "serialized version matches original");
+    }
+
     public function testCompareWithSignature() {
         $success = ['success' => true, 'reason' => null];
 

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -40,15 +40,101 @@ class GroupTest extends \PHPUnit_Framework_TestCase {
     }
 
     // TODO: need to loop versions
-    public function testAsVersion() {
-        $obj = new Group();
+    public function testAsVersionMbox() {
+        $args      = [
+            'mbox' => COMMON_GROUP_MBOX
+        ];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals(
-            [ 'objectType' => 'Group' ],
-            $versioned,
-            "empty: 1.0.0"
-        );
+        $args['objectType'] = 'Group';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionMboxSha1() {
+        $args      = [
+            'mbox_sha1sum' => COMMON_GROUP_MBOX_SHA1
+        ];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Group';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionAccount() {
+        $args      = [
+            'account' => [
+                'name' => COMMON_ACCT_NAME,
+                'homePage' => COMMON_ACCT_HOMEPAGE
+            ]
+        ];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Group';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionAccountEmptyStrings() {
+        $args      = [
+            'account' => [
+                'name' => '',
+                'homePage' => ''
+            ]
+        ];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Group';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyAccount() {
+        $args      = [
+            'account' => []
+        ];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Group';
+        unset($args['account']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyMember() {
+        $args      = [
+            'member' => []
+        ];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Group';
+        unset($args['member']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Group::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'Group';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
     }
 
     public function testAddMember() {

--- a/tests/LanguageMapTest.php
+++ b/tests/LanguageMapTest.php
@@ -29,10 +29,29 @@ class LanguageMapTest extends \PHPUnit_Framework_TestCase {
 
     public function testAsVersion() {
         $args      = ['en' => [self::NAME]];
-        $obj       = new LanguageMap($args);
+
+        $obj       = LanguageMap::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion();
 
-        $this->assertEquals($versioned, $args, "en only: test");
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = LanguageMap::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, null, "serialization returns null");
+    }
+
+    public function testAsVersionValueEmptyString() {
+        $args      = ['en' => ['']];
+
+        $obj       = LanguageMap::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion();
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
     }
 
     public function testGetNegotiatedLanguageString() {

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -76,10 +76,31 @@ class ResultTest extends \PHPUnit_Framework_TestCase {
         $obj       = new Result($args);
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals($versioned, $args, "success only: 1.0.0");
+        $this->assertEquals($versioned, $args, "serialized version matches original");
     }
 
-    // reported https://github.com/RusticiSoftware/TinCanPHP/issues/34
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Result::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionScoreEmpty() {
+        $args = [
+            'score' => []
+        ];
+
+        $obj       = Result::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['score']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
     public function testAsVersionScoreZeroRaw() {
         $args = [
             'score' => [
@@ -91,6 +112,30 @@ class ResultTest extends \PHPUnit_Framework_TestCase {
         $versioned = $obj->asVersion('1.0.0');
 
         $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionResponseEmptyString() {
+        $args = [
+            'response' => ''
+        ];
+
+        $obj       = Result::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionDurationEmptyString() {
+        $args = [
+            'duration' => ''
+        ];
+
+        $obj       = Result::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['duration']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
     }
 
     public function testCompareWithSignature() {

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -135,6 +135,44 @@ class ScoreTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($versioned, $args, "version: 1.0.0");
     }
 
+    public function testAsVersionEmpty() {
+        $obj       = new Score([]);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, [], "version: 1.0.0");
+    }
+
+    public function testAsVersionSingleZero() {
+        $args = [
+            'raw' => 0
+        ];
+        $obj       = new Score($args);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "version: 1.0.0");
+
+        $args = [
+            'scaled' => 0
+        ];
+        $obj       = new Score($args);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "version: 1.0.0");
+    }
+
+    public function testAsVersionWithZeroScores() {
+        $args = [
+            'raw'    => '0',
+            'min'    => '-1.0',
+            'max'    => 2.0,
+            'scaled' => 0
+        ];
+        $obj       = new Score($args);
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "version: 1.0.0");
+    }
+
     public function testCompareWithSignature() {
         $full = [
             'raw'    => 97,

--- a/tests/StatementRefTest.php
+++ b/tests/StatementRefTest.php
@@ -51,13 +51,26 @@ class StatementRefTest extends \PHPUnit_Framework_TestCase {
     // TODO: need to loop versions
     public function testAsVersion() {
         $args = [
-            'objectType' => 'StatementRef',
             'id' => Util::getUUID(),
         ];
-        $obj = new StatementRef($args);
+
+        $obj       = StatementRef::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals($versioned, $args, "version 1.0.0");
+        $args['objectType'] = 'StatementRef';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = StatementRef::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $args['objectType'] = 'StatementRef';
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
     }
 
     public function testCompareWithSignature() {

--- a/tests/VerbTest.php
+++ b/tests/VerbTest.php
@@ -78,10 +78,40 @@ class VerbTest extends \PHPUnit_Framework_TestCase {
             'id' => COMMON_VERB_ID,
             'display' => self::$DISPLAY
         ];
-        $obj = new Verb($args);
+
+        $obj       = Verb::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
         $versioned = $obj->asVersion('1.0.0');
 
-        $this->assertEquals($versioned, $args, "version 1.0.0");
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmpty() {
+        $args = [];
+
+        $obj       = Verb::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
+    }
+
+    public function testAsVersionEmptyLanguageMap() {
+        $args      = ['display' => []];
+
+        $obj       = Verb::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        unset($args['display']);
+
+        $this->assertEquals($versioned, $args, "serialized version matches corrected");
+    }
+
+    public function testAsVersionEmptyStringInLanguageMap() {
+        $args      = ['display' => ['en' => '']];
+
+        $obj       = Verb::fromJSON(json_encode($args, JSON_UNESCAPED_SLASHES));
+        $versioned = $obj->asVersion('1.0.0');
+
+        $this->assertEquals($versioned, $args, "serialized version matches original");
     }
 
     public function testCompareWithSignature() {


### PR DESCRIPTION
Fixes #48 and #52 in a different (and hopefully more thorough) way than #49 and #55. Increases test coverage around `asVersion` methods for most (or all I didn't check) of the models. Ultimately the issue was caused by a recursive call to `asVersion` and ultimately `_asVersion` in the `StatementBase` class that shouldn't have been happening which is why we saw this manifest itself in the `Score` model but only from one level out (IOW instead of in the `Result` case).

No public interface changes.