### PR TITLE
Added "use ErrorException;"

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -17,6 +17,8 @@
 
 namespace TinCan;
 
+use ErrorException;
+
 class RemoteLRS implements LRSInterface
 {
     use ArraySetterTrait;


### PR DESCRIPTION
Added the `use ErrorException;` at the beginning of the file. Without it, PHP will look by default for a class named `TinCan\ErrorException` and will throw a fatal error for class not found.