### PR TITLE
Fixes `Class 'TinCan\ErrorException' not found`

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -127,7 +127,7 @@ class RemoteLRS implements LRSInterface
         //
         set_error_handler(
             function ($errno, $errstr, $errfile, $errline, array $errcontext) {
-                throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
             }
         );
 


### PR DESCRIPTION
Fixes `Class 'TinCan\ErrorException' not found`