### PR TITLE
fix fopen headers for php7

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -94,13 +94,15 @@ class RemoteLRS implements LRSInterface
             //
             'ignore_errors' => true,
 
-            'method' => $method,
-            'header' => array(
-                'X-Experience-API-Version: ' . $this->version
-            ),
+            'method' => $method
         );
+
+        $headers = array(
+            'X-Experience-API-Version: ' . $this->version
+        );
+
         if (isset($this->auth)) {
-            array_push($http['header'], 'Authorization: ' . $this->auth);
+            array_push($headers, 'Authorization: ' . $this->auth);
         }
         if (isset($this->proxy)) {
             $http['proxy'] = $this->proxy;
@@ -108,13 +110,13 @@ class RemoteLRS implements LRSInterface
 
         if (isset($this->headers) && count($this->headers) > 0) {
             foreach ($this->headers as $k => $v) {
-                array_push($http['header'], "$k: $v");
+                array_push($headers, "$k: $v");
             }
         }
 
         if (isset($options['headers'])) {
             foreach ($options['headers'] as $k => $v) {
-                array_push($http['header'], "$k: $v");
+                array_push($headers, "$k: $v");
             }
         }
         if (isset($options['params']) && count($options['params']) > 0) {
@@ -124,9 +126,11 @@ class RemoteLRS implements LRSInterface
         if (($method === 'PUT' || $method === 'POST') && isset($options['content'])) {
             $http['content'] = $options['content'];
             if (is_string($options['content'])) {
-                array_push($http['header'], 'Content-length: ' . strlen($options['content']));
+                array_push($headers, 'Content-length: ' . strlen($options['content']));
             }
         }
+
+        $http['header'] = $headers;
 
         $success = false;
 


### PR DESCRIPTION
With PHP 7 and the current version of the code, for some reason the headers get included in the stream context but are not used by fopen. I think it has something to do with array push inserting a reference to each individual header array, rather than a copy. I'm not sure that's how array push works or why that would cause the issue though. 

The specific error you get (from fopen, it doesn't get as far as hitting the LRS) without this patch is that no content type is specified. 

`Fatal error: Uncaught ErrorException: fopen(): Content-type not specified assuming application/x-www-form-urlencoded`

See http://stackoverflow.com/questions/39085235/fopen-no-authorization-header-with-php-7?noredirect=1#comment65518910_39085235 for a related issue that used similar code. 

Whatever the reason, this patch fixes the issue. 

As a side note, this is the only change I found was required for POST Statements to work under PHP7. I haven't tested any of the other calls. This change isn't in https://github.com/RusticiSoftware/TinCanPHP/pull/47 - I'm not sure why this problem didn't come up there. 