### PR TITLE
Test Coverage improvement and various fixes

### DIFF
--- a/src/AsVersionTrait.php
+++ b/src/AsVersionTrait.php
@@ -46,7 +46,7 @@ trait AsVersionTrait
             if ($value instanceof VersionableInterface) {
                 $value = $value->asVersion($version);
             }
-            else if (is_array($value) && !empty($value)) {
+            elseif (is_array($value) && !empty($value)) {
                 $tmp_value = array();
                 foreach ($value as $element) {
                     if ($element instanceof VersionableInterface) {

--- a/src/Map.php
+++ b/src/Map.php
@@ -55,7 +55,7 @@ abstract class Map implements VersionableInterface
                 return $this->_unset($args[0]);
             break;
             default:
-                throw new BadMethodCallException(__CLASS__ . "::$func() does not exist");
+                throw new \BadMethodCallException(get_class($this) . "::$func() does not exist");
         }
     }
 }

--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -229,7 +229,7 @@ class RemoteLRS implements LRSInterface
                 if ($pair[0] === 'charset') {
                     $result['headers']['contentTypeCharset'] = $pair[1];
                 }
-                else if ($pair[0] === 'boundary') {
+                elseif ($pair[0] === 'boundary') {
                     $result['headers']['contentTypeBoundary'] = $pair[1];
                 }
             }
@@ -246,7 +246,7 @@ class RemoteLRS implements LRSInterface
             if ($part === '') {
                 continue;
             }
-            else if ($part === '--') {
+            elseif ($part === '--') {
                 break;
             }
             list($header, $body) = explode("\r\n\r\n", $part, 2);
@@ -956,7 +956,7 @@ class RemoteLRS implements LRSInterface
     public function retrieveActivity($activityid) {
         $headers = array('Accept-language: *');
         if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-            $headers = 'Accept-language: ' . $_SERVER['HTTP_ACCEPT_LANGUAGE'] . ', *';
+            $headers = array('Accept-language: ' . $_SERVER['HTTP_ACCEPT_LANGUAGE'] . ', *');
         }
 
         $response = $this->sendRequest(

--- a/src/SignatureComparisonTrait.php
+++ b/src/SignatureComparisonTrait.php
@@ -68,7 +68,7 @@ trait SignatureComparisonTrait
         }
 
         if (is_object($a) && ! ($b instanceof $a)) {
-            $result['reason'] = "Comparison of $description failed: not a " . get_class($this) . " value";
+            $result['reason'] = "Comparison of $description failed: not a " . get_class($a) . " value";
             return $result;
         }
 

--- a/src/State.php
+++ b/src/State.php
@@ -52,7 +52,7 @@ class State extends Document
 
     public function setRegistration($value) {
         if (isset($value) && ! preg_match(Util::UUID_REGEX, $value)) {
-            throw new InvalidArgumentException('arg1 must be a UUID');
+            throw new \InvalidArgumentException('arg1 must be a UUID');
         }
 
         $this->registration = $value;

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -249,7 +249,7 @@ class Statement extends StatementBase
         if (isset($options['publicKey'])) {
             $publicKeyFile = $options['publicKey'];
         }
-        else if (isset($header['x5c'])) {
+        elseif (isset($header['x5c'])) {
             $cert = "-----BEGIN CERTIFICATE-----\r\n" . chunk_split($header['x5c'][0], 64, "\r\n") . "-----END CERTIFICATE-----\r\n";
             $cert = openssl_x509_read($cert);
             if (! $cert) {

--- a/tests/ActivityProfileTest.php
+++ b/tests/ActivityProfileTest.php
@@ -1,0 +1,30 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\ActivityProfile;
+use TinCan\Activity;
+
+class ActivityProfileTest extends \PHPUnit_Framework_TestCase {
+    public function testSetActivity() {
+        $profile = new ActivityProfile();
+        $profile->setActivity(['id' => COMMON_ACTIVITY_ID]);
+
+        $this->assertInstanceOf('TinCan\Activity', $profile->getActivity());
+    }
+}

--- a/tests/AgentProfileTest.php
+++ b/tests/AgentProfileTest.php
@@ -1,0 +1,35 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\AgentProfile;
+use TinCan\Agent;
+use TinCan\Group;
+
+class AgentProfileTest extends \PHPUnit_Framework_TestCase {
+    public function testSetAgent() {
+        $profile = new AgentProfile();
+        $profile->setAgent(['mbox' => COMMON_MBOX]);
+
+        $this->assertInstanceOf('TinCan\Agent', $profile->getAgent());
+
+        $profile->setAgent(['objectType' => 'Group']);
+
+        $this->assertInstanceOf('TinCan\Group', $profile->getAgent());
+    }
+}

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -276,4 +276,26 @@ class ContextActivitiesTest extends \PHPUnit_Framework_TestCase {
         }
         $this->runSignatureCases("TinCan\ContextActivities", $cases);
     }
+
+    /**
+     * @dataProvider invalidListSetterDataProvider
+     */
+    public function testListSetterThrowsInvalidArgumentException($publicMethodName, $invalidValue) {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'type of arg1 must be Activity, array of Activity properties, or array of Activity/array of Activity properties'
+        );
+        $obj = new ContextActivities();
+        $obj->$publicMethodName($invalidValue);
+    }
+
+    public function invalidListSetterDataProvider() {
+        $invalidValue = 1;
+        return [
+            ["setCategory", $invalidValue],
+            ["setParent", $invalidValue],
+            ["setGrouping", $invalidValue],
+            ["setOther", $invalidValue]
+        ];
+    }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -359,4 +359,23 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
         ];
         $this->runSignatureCases("TinCan\Context", $cases);
     }
+
+    public function testSetInstructorConvertToGroup() {
+        $obj = new Context();
+        $obj->setInstructor(
+            [
+                'objectType' => 'Group'
+            ]
+        );
+        $this->assertInstanceOf('TinCan\Group', $obj->getInstructor());
+    }
+
+    public function testSetRegistrationInvalidArgumentException() {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'arg1 must be a UUID'
+        );
+        $obj = new Context();
+        $obj->setRegistration('232....3.3..3./2/2/1m3m3m3');
+    }
 }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -1,0 +1,34 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\Document;
+
+class StubDocument extends Document {}
+
+class DocumentTest extends \PHPUnit_Framework_TestCase {
+    public function testExceptionOnInvalidDateTime() {
+        $this->setExpectedException(
+            "InvalidArgumentException",
+            'type of arg1 must be string or DateTime'
+        );
+
+        $obj = new StubDocument();
+        $obj->setTimestamp(1);
+    }
+}

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -149,6 +149,9 @@ class GroupTest extends \PHPUnit_Framework_TestCase {
 
         $obj->addMember($common_agent);
         $this->assertEquals([$common_agent], $obj->getMember(), 'member list existing Agent');
+
+        $versioned = $obj->asVersion('1.0.0');
+        $this->assertSame($versioned['member'][0], $common_agent->asVersion('1.0.0'));
     }
 
     public function testCompareWithSignature() {

--- a/tests/LRSResponseTest.php
+++ b/tests/LRSResponseTest.php
@@ -1,0 +1,29 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\LRSResponse;
+
+class LRSResponseTest extends \PHPUnit_Framework_TestCase {
+    public function testInstantiation() {
+        $obj = new LRSResponse(true, '', false);
+        $this->assertTrue($obj->success);
+        $this->assertEquals('', $obj->content);
+        $this->assertFalse($obj->httpResponse);
+    }
+}

--- a/tests/LanguageMapTest.php
+++ b/tests/LanguageMapTest.php
@@ -66,5 +66,23 @@ class LanguageMapTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals($usValue, $langs['en-US'], 'US name equal');
         $this->assertEquals($ukValue, $langs['en-GB'], 'UK name equal');
+
+        $nullValue = $obj->getNegotiatedLanguageString();
+        $this->assertEquals($nullValue, $langs['en-GB'], 'from null: UK name equal');
+
+        if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+            $restore = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+        }
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US';
+
+        $nullAcceptValue = $obj->getNegotiatedLanguageString();
+        $this->assertEquals($nullAcceptValue, $langs['en-US'], 'from server: US name equal');
+
+        if (isset($restore)) {
+            $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $restore;
+        }
+        else {
+            unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        }
     }
 }

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1,0 +1,60 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\Map;
+
+class StubMap extends Map {}
+
+class MapTest extends \PHPUnit_Framework_TestCase {
+    public function testInstantiation() {
+        $obj = new StubMap();
+    }
+
+    public function testInstantiationWithArg() {
+        $obj = new StubMap([]);
+        $this->assertTrue($obj->isEmpty());
+    }
+
+    public function testSetUnset() {
+        $obj = new StubMap();
+
+        $code = 'code';
+        $value = 'value';
+
+        $obj->set($code, $value);
+
+        $this->assertEquals($value, $obj->asVersion()[$code]);
+
+        $obj->unset($code);
+
+        $this->assertFalse(isset($obj->asVersion()[$code]));
+    }
+
+    public function testExceptionOnBadMethodCall() {
+        $badName ="dsadasdasdasdasdasdas";
+
+        $this->setExpectedException(
+            '\BadMethodCallException',
+            get_class(new StubMap) . "::$badName() does not exist"
+        );
+
+        $obj = new StubMap();
+        $obj->$badName();
+    }
+}

--- a/tests/RemoteLRSTest.php
+++ b/tests/RemoteLRSTest.php
@@ -527,6 +527,11 @@ class RemoteLRSTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($testActivity, $response->content, 'retrieved activity');
     }
 
+    public function testRetrieveActivityWithHttpAcceptLanguageHeader() {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US';
+        $this->testRetrieveActivity();
+    }
+
     public function testRetrieveAgentProfileIds() {
         $lrs = new RemoteLRS(self::$endpoint, self::$version, self::$username, self::$password);
         $response = $lrs->retrieveAgentProfileIds(

--- a/tests/RemoteLRSTest.php
+++ b/tests/RemoteLRSTest.php
@@ -80,6 +80,29 @@ class RemoteLRSTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($response->content, $statement, 'content');
     }
 
+    public function testSaveStatementStamped() {
+        $lrs = new RemoteLRS(self::$endpoint, self::$version, self::$username, self::$password);
+        $statement = new Statement(
+            [
+                'actor' => [
+                    'mbox' => COMMON_MBOX
+                ],
+                'verb' => [
+                    'id' => COMMON_VERB_ID
+                ],
+                'object' => new Activity([
+                    'id' => COMMON_ACTIVITY_ID
+                ])
+            ]
+        );
+        $statement->stamp();
+
+        $response = $lrs->saveStatement($statement);
+        $this->assertInstanceOf('TinCan\LRSResponse', $response);
+        $this->assertTrue($response->success, 'success');
+        $this->assertSame($response->content, $statement, 'content');
+    }
+
     public function testSaveStatements() {
         $lrs = new RemoteLRS(self::$endpoint, self::$version, self::$username, self::$password);
         $statements = [

--- a/tests/SignatureComparisonTraitTest.php
+++ b/tests/SignatureComparisonTraitTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+class SignatureComparisonStub {
+    use \TinCan\SignatureComparisonTrait;
+
+    public static function runDoMatch($a, $b, $description) {
+        return self::doMatch($a, $b, $description);
+    }
+}
+
+class SignatureComparisonTraitTest extends \PHPUnit_Framework_TestCase {
+    public function testDoMatch() {
+        $description = "A test Description";
+
+        $a = new \stdClass;
+        $result = SignatureComparisonStub::runDoMatch($a, false, $description);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of $description failed: not a " . get_class($a) . " value", $result['reason']);
+
+        $result = SignatureComparisonStub::runDoMatch([], false, $description);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of $description failed: not an array in signature", $result['reason']);
+    }
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\State;
+use TinCan\Group;
+
+class StateTest extends \PHPUnit_Framework_TestCase {
+    public function testCanSetActivityWithArray() {
+        $args = [
+            'id' => COMMON_ACTIVITY_ID,
+            'definition' => []
+        ];
+
+        $state = new State();
+        $state->setActivity($args);
+    }
+
+    public function testSetAgent() {
+        $obj = new State();
+        $obj->setAgent(['mbox' => COMMON_MBOX]);
+
+        $this->assertInstanceOf('TinCan\Agent', $obj->getAgent());
+
+        $group = new Group();
+        $obj->setAgent(['objectType' => 'Group']);
+
+        $this->assertInstanceOf('TinCan\Group', $obj->getAgent());
+    }
+
+    public function testExceptionOnInvalidRegistrationUUID() {
+        $this->setExpectedException(
+            "InvalidArgumentException",
+            'arg1 must be a UUID'
+        );
+
+        $obj = new State();
+        $obj->setRegistration('232....3.3..3./2/2/1m3m3m3');
+    }
+}

--- a/tests/StatementBaseTest.php
+++ b/tests/StatementBaseTest.php
@@ -1,0 +1,173 @@
+<?php
+/*
+    Copyright 2016 Rustici Software
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+namespace TinCanTest;
+
+use TinCan\StatementBase;
+use TinCan\SubStatement;
+use TinCan\Verb;
+use TinCan\Agent;
+use TinCan\Context;
+use TinCan\Result;
+
+class StubStatementBase extends StatementBase {}
+
+class StatementBaseTest extends \PHPUnit_Framework_TestCase {
+    public function testInstantiation() {
+        $obj = new StubStatementBase();
+    }
+
+    public function testSetTargetAsSAgent() {
+        $obj = new StubStatementBase();
+        $ss = [
+            'objectType' => 'Agent'
+        ];
+        $obj->setTarget($ss);
+        $this->assertInstanceOf('TinCan\Agent', $obj->getTarget());
+    }
+
+    public function testSetTargetAsGroup() {
+        $obj = new StubStatementBase();
+        $ss = [
+            'objectType' => 'Group'
+        ];
+        $obj->setTarget($ss);
+        $this->assertInstanceOf('TinCan\Group', $obj->getTarget());
+    }
+
+    public function testSetTargetAsSubStatement() {
+        $obj = new StubStatementBase();
+        $ss = [
+            'objectType' => 'SubStatement'
+        ];
+        $obj->setTarget($ss);
+        $this->assertInstanceOf('TinCan\SubStatement', $obj->getTarget());
+    }
+
+    public function testSetTargetInvalidArgumentException() {
+        $badObjectType = 'imABadObjectType';
+        $this->setExpectedException(
+            "InvalidArgumentException",
+            "arg1 must implement the StatementTargetInterface objectType not recognized:$badObjectType"
+        );
+        $obj = new StubStatementBase();
+        $ss = [
+            'objectType' => $badObjectType
+        ];
+        $obj->setTarget($ss);
+    }
+
+    public function testSetActorAsGroup() {
+        $obj = new StubStatementBase();
+        $ss = [
+            'objectType' => 'Group'
+        ];
+        $obj->setActor($ss);
+        $this->assertInstanceOf('TinCan\Group', $obj->getActor());
+    }
+
+    public function testSetTimestampInvalidArgumentException() {
+        $this->setExpectedException(
+            "InvalidArgumentException",
+            'type of arg1 must be string or DateTime'
+        );
+
+        $obj = new StubStatementBase();
+        $obj->setTimestamp(1);
+    }
+
+    /**
+     * @dataProvider statementPropertyValueProvider
+     */
+    public function testCompareWithSignaturePropertyMissing($property, $value) {
+        $signature = new \stdClass;
+        $setMethodName = 'set' . ucfirst($property);
+
+        $obj = new StubStatementBase();
+        $obj->$setMethodName($value);
+
+        $result = $obj->compareWithSignature($signature);
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of $property failed: value not in signature", $result['reason']);
+
+        $obj = new StubStatementBase();
+        $signature->$property = $value;
+
+        $result = $obj->compareWithSignature($signature);
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of $property failed: value not in this", $result['reason']);
+    }
+
+    public function statementPropertyValueProvider() {
+        return [
+            ['actor',   new Agent()],
+            ['verb',    new Verb()],
+            ['target',  new Agent()],
+            ['context', new Context()],
+            ['result',  new Result()],
+        ];
+    }
+
+    public function testCompareWithSignatureTimestampMissing() {
+        $timestamp = "2004-02-12T15:19:21+00:00";
+        $signature = new \stdClass;
+
+        $obj = new StubStatementBase();
+        $obj->setTimestamp($timestamp);
+
+        $result = $obj->compareWithSignature($signature);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of timestamp failed: value not in signature", $result['reason']);
+
+        $obj = new StubStatementBase();
+        $signature->timestamp = $timestamp;
+
+        $result = $obj->compareWithSignature($signature);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of timestamp failed: value not in this", $result['reason']);
+    }
+
+    public function testCompareWithSignatureTimestampNotEqual() {
+        $timestamp = "2004-02-12T15:19:21+00:00";
+        $signature = new \stdClass;
+
+        $obj = new StubStatementBase();
+        $obj->setTimestamp($timestamp);
+        $signature->timestamp = "2005-02-12T15:19:21+00:00";
+
+        $result = $obj->compareWithSignature($signature);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of timestamp failed: value is not the same", $result['reason']);
+
+        //Now check with microseconds.
+        $timestamp = "2012-07-08 11:14:15.638276";
+        $obj = new StubStatementBase();
+        $obj->setTimestamp($timestamp);
+        $signature->timestamp = "2012-07-08 11:14:15.638286";
+
+        $dt = new \DateTime($timestamp);
+        $dt2 = new \DateTime($signature->timestamp);
+
+        $result = $obj->compareWithSignature($signature);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals("Comparison of timestamp failed: value is not the same", $result['reason']);
+    }
+}

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -70,6 +70,25 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
         $obj = Statement::fromJSON('{id:"some value"}');
     }
 
+    public function testConstructionFromArrayWithId() {
+        $id = Util::getUUID();
+        $cfg = [
+            'id' => $id,
+            'actor' => [
+                'mbox' => COMMON_MBOX,
+            ],
+            'verb' => [
+                'id' => COMMON_VERB_ID,
+            ],
+            'object' => [
+                'id' => COMMON_ACTIVITY_ID,
+            ],
+        ];
+        $obj = new Statement($cfg);
+
+        $this->assertSame($obj->getId(), $id, 'id');
+    }
+
     public function testStamp() {
         $obj = new Statement();
         $obj->stamp();

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -107,6 +107,16 @@ class StatementTest extends \PHPUnit_Framework_TestCase {
         $obj->setId('some invalid id');
     }
 
+    public function testSetStoredInvalidArgumentException() {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'type of arg1 must be string or DateTime'
+        );
+
+        $obj = new Statement();
+        $obj->setStored(1);
+    }
+
     // TODO: need to loop versions
     public function testAsVersion() {
         $args = [

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -54,4 +54,20 @@ class VersionTest extends \PHPUnit_Framework_TestCase {
     public function testLatest() {
         $this->assertSame(Version::V101, Version::latest(), "match latest");
     }
+
+    public function testVersionFromString() {
+        $number = '1.0.1';
+        $version = Version::fromString($number);
+
+        $this->assertTrue($version->hasValue($number));
+    }
+
+    public function testInvalidArgumentExceptionIsThrown() {
+        $number = '1.8.01';
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            "Invalid version [$number]"
+        );
+        $version = Version::fromString($number);
+    }
 }


### PR DESCRIPTION
This is another round of changes reviewed from #47 that apply to the 0.x release and aren't related to PHP 7 compatibility.

Fixes include:
* Exception namespace issue in `Map` and `State`
* Accept-Language header issue in `RemoteLRS.retrieveActivity`
* Incorrect class in failure reason in `SignatureComparisonTrait`