### PR TITLE
restore scaled value functionality

### DIFF
--- a/src/Score.php
+++ b/src/Score.php
@@ -72,15 +72,15 @@ class Score implements VersionableInterface, ComparableInterface
      * @param float|array $aRawValue      the score value, may also be an array of properties
      * @param float       $aMin           the score minimum
      * @param float       $aMax           the score maximum
-     * @param float       $aScalingFactor the score scaling factor
+     * @param float       $aScaledValue   the scaled value
      */
-    public function __construct($aRawValue = null, $aMin = null, $aMax = null, $aScalingFactor = null) {
+    public function __construct($aRawValue = null, $aMin = null, $aMax = null, $aScaledValue = null) {
         if (!is_array($aRawValue)) {
             $aRawValue = [
                 'raw'    => $aRawValue,
                 'min'    => $aMin,
                 'max'    => $aMax,
-                'scaled' => $aScalingFactor
+                'scaled' => $aScaledValue
             ];
         }
         $this->_fromArray($aRawValue);
@@ -104,15 +104,9 @@ class Score implements VersionableInterface, ComparableInterface
 
     /**
      * @param  int $aPrecision a rounding precision integer
-     * @return null|float
+     * @return float
      */
     public function getValue($aPrecision = self::DEFAULT_PRECISION) {
-        if (!isset($this->raw)) {
-            return null;
-        }
-        if (isset($this->scaled)) {
-            return round($this->raw * $this->scaled, $aPrecision);
-        }
         return round($this->raw, $aPrecision);
     }
 

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -98,26 +98,11 @@ class ScoreTest extends \PHPUnit_Framework_TestCase {
         $this->assertInternalType('float', $score->getScaled());
     }
 
-    public function testGetValueWithoutRawReturnsNull() {
-        $score = new Score;
-        $this->assertNull($score->getValue());
-    }
-
-    public function testGetValueWithoutScaledReturnsRoundedRaw() {
+    public function testGetValueReturnsRoundedRaw() {
         $raw   = 3.92013;
         $score = new Score($raw);
         $this->assertEquals(
             round($raw, Score::DEFAULT_PRECISION),
-            $score->getValue()
-        );
-    }
-
-    public function testGetValueWithScaledReturnsScaledAndRoundedRaw() {
-        $raw    = 3.92013;
-        $scaled = 0.8;
-        $score  = new Score($raw, null, null, $scaled);
-        $this->assertEquals(
-            round($raw * $scaled, Score::DEFAULT_PRECISION),
             $score->getValue()
         );
     }


### PR DESCRIPTION
fixes #74 

I'm still not clear on how a [mastery score](http://support.scorm.com/hc/en-us/articles/206166246-Setting-the-mastery-score) is calculated or used, but this will restore expected functionality.