### PR TITLE
Fix code smells

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -149,6 +149,8 @@ class Agent implements VersionableInterface, StatementTargetInterface, Comparabl
         if (isset($this->mbox)) {
             return sha1($this->mbox);
         }
+
+        return null;
     }
     public function setOpenid($value) { $this->openid = $value; return $this; }
     public function getOpenid() { return $this->openid; }

--- a/src/Map.php
+++ b/src/Map.php
@@ -33,9 +33,7 @@ abstract class Map implements VersionableInterface
     }
 
     public function asVersion($version = null) {
-        if (! $this->isEmpty()) {
-            return $this->_map;
-        }
+        return $this->isEmpty() ? null : $this->_map;
     }
 
     public function set($code, $value) {

--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -163,7 +163,7 @@ class RemoteLRS implements LRSInterface
             $metadata = stream_get_meta_data($fp);
             $content  = stream_get_contents($fp);
 
-            $response = $this->_parseMetadata($metadata, $options);
+            $response = $this->_parseMetadata($metadata);
 
             //
             // keep a copy of the raw content, the methods expecting

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -194,7 +194,7 @@ class Statement extends StatementBase
         }
         $jws = new JWS($jwsHeader);
 
-        $jws->setPayload($serialization, false);
+        $jws->setPayload($serialization);
         $jws->sign($privateKey);
 
         $attachment = array(


### PR DESCRIPTION
Found and fixed issues that are considered code smells:
* method calls with mismatched number of parameters
* inconsistent return points in methods with missing return statements
