### PR TITLE
Fix ContextTest comparison of ContextActivities signatures.

### DIFF
--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -167,11 +167,15 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
             [ 'account' => [ 'homePage' => COMMON_ACCT_HOMEPAGE, 'name' => COMMON_ACCT_NAME ]]
         );
         $contextActivities1 = new ContextActivities(
-            [ 'parent' => [ COMMON_ACTIVITY_ID ]]
+            [
+                'parent' => [ COMMON_ACTIVITY_ID ]
+            ]
         );
         $contextActivities2 = new ContextActivities(
-            [ 'parent' => [ COMMON_ACTIVITY_ID . '/parent' ]],
-            [ 'grouping' => [ COMMON_ACTIVITY_ID ]]
+            [
+                'parent' => [ COMMON_ACTIVITY_ID . '/parent' ],
+                'grouping' => [ COMMON_ACTIVITY_ID ]
+            ]
         );
         $ref1 = new StatementRef(
             [ 'id' => Util::getUUID() ]
@@ -270,7 +274,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
                 'description' => 'contextActivities only: mismatch',
                 'objArgs'     => ['contextActivities' => $contextActivities1 ],
                 'sigArgs'     => ['contextActivities' => $contextActivities2 ],
-                'reason'      => 'Comparison of contextActivities failed: Comparison of parent failed: array lengths differ'
+                'reason'      => 'Comparison of contextActivities failed: Comparison of grouping failed: array lengths differ'
             ],
             [
                 'description' => 'revision only: mismatch',
@@ -324,7 +328,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase {
                 'description' => 'full: contextActivities mismatch',
                 'objArgs'     => $full,
                 'sigArgs'     => array_replace($full, ['contextActivities' => $contextActivities2]),
-                'reason'      => 'Comparison of contextActivities failed: Comparison of parent failed: array lengths differ'
+                'reason'      => 'Comparison of contextActivities failed: Comparison of grouping failed: array lengths differ'
             ],
             [
                 'description' => 'full: revision mismatch',


### PR DESCRIPTION
The grouping array was sent as argument 2 to the $contextActivities2 constructor. ContextActivities->__construct() only takes one argument and will not assign ANY properties if there is not exactly one argument. This cause $contextActivities2 to have a different number of parents than $contextActivities1. I believe the intent of 'contextActivities only: mismatch' and 'full: contextActivities mismatch' cases is to detect differences in the number of contextActivities->grouping objects.