### PR TITLE
Changed PHPUnit_Framework_TestCase to PHPUnit\Framework\TestCase

### DIFF
--- a/tests/AboutTest.php
+++ b/tests/AboutTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\About;
 
-class AboutTest extends \PHPUnit_Framework_TestCase {
+class AboutTest extends TestCase {
     const VERSION_1 = '1.0.0';
 
     public function testInstantiation() {

--- a/tests/ActivityDefinitionTest.php
+++ b/tests/ActivityDefinitionTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\ActivityDefinition;
 
-class ActivityDefinitionTest extends \PHPUnit_Framework_TestCase {
+class ActivityDefinitionTest extends TestCase {
     const NAME = 'testName';
 
     private $emptyProperties = array(

--- a/tests/ActivityProfileTest.php
+++ b/tests/ActivityProfileTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\ActivityProfile;
 use TinCan\Activity;
 
-class ActivityProfileTest extends \PHPUnit_Framework_TestCase {
+class ActivityProfileTest extends TestCase {
     public function testSetActivity() {
         $profile = new ActivityProfile();
         $profile->setActivity(['id' => COMMON_ACTIVITY_ID]);

--- a/tests/ActivityTest.php
+++ b/tests/ActivityTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 
-class ActivityTest extends \PHPUnit_Framework_TestCase {
+class ActivityTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     static private $DEFINITION;

--- a/tests/ActivityTest.php
+++ b/tests/ActivityTest.php
@@ -44,17 +44,17 @@ class ActivityTest extends TestCase {
     }
 
     public function testFromJSONInvalidNull() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Activity::fromJSON(null);
     }
 
     public function testFromJSONInvalidEmptyString() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Activity::fromJSON('');
     }
 
     public function testFromJSONInvalidMalformed() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Activity::fromJSON('{id:"some value"}');
     }
 

--- a/tests/AgentAccountTest.php
+++ b/tests/AgentAccountTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\AgentAccount;
 
-class AgentAccountTest extends \PHPUnit_Framework_TestCase {
+class AgentAccountTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     const HOMEPAGE = 'http://tincanapi.com';

--- a/tests/AgentProfileTest.php
+++ b/tests/AgentProfileTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\AgentProfile;
 use TinCan\Agent;
 use TinCan\Group;
 
-class AgentProfileTest extends \PHPUnit_Framework_TestCase {
+class AgentProfileTest extends TestCase {
     public function testSetAgent() {
         $profile = new AgentProfile();
         $profile->setAgent(['mbox' => COMMON_MBOX]);

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Agent;
 use TinCan\AgentAccount;
 
-class AgentTest extends \PHPUnit_Framework_TestCase {
+class AgentTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -35,17 +35,17 @@ class AgentTest extends TestCase {
     }
 
     public function testFromJSONInvalidNull() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Agent::fromJSON(null);
     }
 
     public function testFromJSONInvalidEmptyString() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Agent::fromJSON('');
     }
 
     public function testFromJSONInvalidMalformed() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Agent::fromJSON('{name:"some value"}');
     }
 

--- a/tests/AsVersionTraitTest.php
+++ b/tests/AsVersionTraitTest.php
@@ -17,7 +17,9 @@
 
 namespace TinCanTest;
 
-class AsVersionTraitTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AsVersionTraitTest extends TestCase
 {
     public function testTraitExists() {
         $this->assertTrue(trait_exists('TinCan\AsVersionTrait'));

--- a/tests/AsVersionTraitTest.php
+++ b/tests/AsVersionTraitTest.php
@@ -31,7 +31,7 @@ class AsVersionTraitTest extends TestCase
     }
 
     public function testMagicSetThrowsException() {
-        $this->setExpectedException('DomainException');
+        $this->expectException('DomainException');
         $trait = $this->getMockForTrait('TinCan\AsVersionTrait');
         $trait->foo = 'bar';
     }

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Attachment;
 use TinCan\Version;
 
-class AttachmentTest extends \PHPUnit_Framework_TestCase {
+class AttachmentTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     const USAGE_TYPE     = 'http://id.tincanapi.com/attachment/supporting_media';

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\ContextActivities;
 
-class ContextActivitiesTest extends \PHPUnit_Framework_TestCase {
+class ContextActivitiesTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     static private $listProps = ['category', 'parent', 'grouping', 'other'];

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -282,8 +282,8 @@ class ContextActivitiesTest extends TestCase {
      * @dataProvider invalidListSetterDataProvider
      */
     public function testListSetterThrowsInvalidArgumentException($publicMethodName, $invalidValue) {
-        $this->setExpectedException(
-            'InvalidArgumentException',
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
             'type of arg1 must be Activity, array of Activity properties, or array of Activity/array of Activity properties'
         );
         $obj = new ContextActivities();

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Agent;
 use TinCan\Context;
 use TinCan\ContextActivities;
@@ -25,7 +26,7 @@ use TinCan\Group;
 use TinCan\StatementRef;
 use TinCan\Util;
 
-class ContextTest extends \PHPUnit_Framework_TestCase {
+class ContextTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     private $emptyProperties = array(

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -372,10 +372,8 @@ class ContextTest extends TestCase {
     }
 
     public function testSetRegistrationInvalidArgumentException() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'arg1 must be a UUID'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('arg1 must be a UUID');
         $obj = new Context();
         $obj->setRegistration('232....3.3..3./2/2/1m3m3m3');
     }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Document;
 
 class StubDocument extends Document {}
 
-class DocumentTest extends \PHPUnit_Framework_TestCase {
+class DocumentTest extends TestCase {
     public function testExceptionOnInvalidDateTime() {
         $this->setExpectedException(
             "InvalidArgumentException",

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -24,10 +24,8 @@ class StubDocument extends Document {}
 
 class DocumentTest extends TestCase {
     public function testExceptionOnInvalidDateTime() {
-        $this->setExpectedException(
-            "InvalidArgumentException",
-            'type of arg1 must be string or DateTime'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('type of arg1 must be string or DateTime');
 
         $obj = new StubDocument();
         $obj->setTimestamp(1);

--- a/tests/ExtensionsTest.php
+++ b/tests/ExtensionsTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Extensions;
 
-class ExtensionsTest extends \PHPUnit_Framework_TestCase {
+class ExtensionsTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Agent;
 use TinCan\AgentAccount;
 use TinCan\Group;
 
-class GroupTest extends \PHPUnit_Framework_TestCase {
+class GroupTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/ISO8601Test.php
+++ b/tests/ISO8601Test.php
@@ -19,10 +19,11 @@ namespace TinCanTest;
 
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use TinCan\Statement;
 use TinCan\State;
 
-class ISO8601Test extends \PHPUnit_Framework_TestCase {
+class ISO8601Test extends TestCase {
     public function testProperties() {
         $str_datetime = '2014-12-15T19:16:05+00:00';
         $str_datetime_tz = '2014-12-15T13:16:05-06:00';

--- a/tests/JSONParseErrorExceptionTest.php
+++ b/tests/JSONParseErrorExceptionTest.php
@@ -15,9 +15,12 @@
     limitations under the License.
 */
 
+namespace TinCanTest;
+
+use PHPUnit\Framework\TestCase;
 use TinCan\JSONParseErrorException;
 
-class JSONParseErrorExceptionTest extends PHPUnit_Framework_TestCase
+class JSONParseErrorExceptionTest extends TestCase
 {
     private $exception;
     private $malformedValue  = '.....';

--- a/tests/LRSResponseTest.php
+++ b/tests/LRSResponseTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\LRSResponse;
 
-class LRSResponseTest extends \PHPUnit_Framework_TestCase {
+class LRSResponseTest extends TestCase {
     public function testInstantiation() {
         $obj = new LRSResponse(true, '', false);
         $this->assertTrue($obj->success);

--- a/tests/LanguageMapTest.php
+++ b/tests/LanguageMapTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\LanguageMap;
 
-class LanguageMapTest extends \PHPUnit_Framework_TestCase {
+class LanguageMapTest extends TestCase {
     const NAME = 'testName';
 
     public function testInstantiation() {

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Map;
 
 class StubMap extends Map {}
 
-class MapTest extends \PHPUnit_Framework_TestCase {
+class MapTest extends TestCase {
     public function testInstantiation() {
         $obj = new StubMap();
     }

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -50,10 +50,8 @@ class MapTest extends TestCase {
     public function testExceptionOnBadMethodCall() {
         $badName ="dsadasdasdasdasdasdas";
 
-        $this->setExpectedException(
-            '\BadMethodCallException',
-            get_class(new StubMap) . "::$badName() does not exist"
-        );
+        $this->expectException('\BadMethodCallException');
+        $this->expectExceptionMessage(get_class(new StubMap) . "::$badName() does not exist");
 
         $obj = new StubMap();
         $obj->$badName();

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Person;
 
-class PersonTest extends \PHPUnit_Framework_TestCase {
+class PersonTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -34,17 +34,17 @@ class PersonTest extends TestCase {
     }
 
     public function testFromJSONInvalidNull() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Person::fromJSON(null);
     }
 
     public function testFromJSONInvalidEmptyString() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Person::fromJSON('');
     }
 
     public function testFromJSONInvalidMalformed() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Person::fromJSON('{name:"some value"}');
     }
 

--- a/tests/RemoteLRSTest.php
+++ b/tests/RemoteLRSTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\Agent;
 use TinCan\Attachment;
@@ -28,7 +29,7 @@ use TinCan\Util;
 use TinCan\Verb;
 use TinCan\Version;
 
-class RemoteLRSTest extends \PHPUnit_Framework_TestCase {
+class RemoteLRSTest extends TestCase {
     static private $endpoint;
     static private $version;
     static private $username;

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Extensions;
 use TinCan\Result;
 use TinCan\Score;
 
-class ResultTest extends \PHPUnit_Framework_TestCase {
+class ResultTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     private $emptyProperties = array(

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Score;
 
-class ScoreTest extends \PHPUnit_Framework_TestCase {
+class ScoreTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     private $emptyProperties = array(

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -59,8 +59,8 @@ class ScoreTest extends TestCase {
     }
 
     public function testSetScaledBelowMin() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
             sprintf('Value must be greater than or equal to %s [-5]', Score::SCALE_MIN)
         );
         $score = new Score;
@@ -68,8 +68,8 @@ class ScoreTest extends TestCase {
     }
 
     public function testSetScaledAboveMax() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
             sprintf('Value must be less than or equal to %s [5]', Score::SCALE_MAX)
         );
         $score = new Score;
@@ -97,19 +97,15 @@ class ScoreTest extends TestCase {
     }
 
     public function testSetRawBelowMin() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Value must be greater than or equal to \'min\' (60) [50]'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Value must be greater than or equal to \'min\' (60) [50]');
         $score = new Score(['min' => 60]);
         $score->setRaw(50);
     }
 
     public function testSetRawAboveMax() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Value must be less than or equal to \'max\' (90) [95]'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Value must be less than or equal to \'max\' (90) [95]');
         $score = new Score(['max' => 90]);
         $score->setRaw(95);
     }
@@ -131,19 +127,15 @@ class ScoreTest extends TestCase {
     }
 
     public function testSetMinAboveRaw() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Value must be less than or equal to \'raw\' (50) [60]'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Value must be less than or equal to \'raw\' (50) [60]');
         $score = new Score(['raw' => 50]);
         $score->setMin(60);
     }
 
     public function testSetMinAboveMax() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Value must be less than \'max\' (90) [95]'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Value must be less than \'max\' (90) [95]');
         $score = new Score(['max' => 90]);
         $score->setMin(95);
     }
@@ -165,19 +157,15 @@ class ScoreTest extends TestCase {
     }
 
     public function testSetMaxBelowRaw() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Value must be greater than or equal to \'raw\' (60) [50]'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Value must be greater than or equal to \'raw\' (60) [50]');
         $score = new Score(['raw' => 60]);
         $score->setMax(50);
     }
 
     public function testSetMaxBelowMin() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Value must be greater than \'min\' (10) [5]'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Value must be greater than \'min\' (10) [5]');
         $score = new Score(['min' => 10]);
         $score->setMax(5);
     }

--- a/tests/SignatureComparisonTraitTest.php
+++ b/tests/SignatureComparisonTraitTest.php
@@ -17,6 +17,8 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
+
 class SignatureComparisonStub {
     use \TinCan\SignatureComparisonTrait;
 
@@ -25,7 +27,7 @@ class SignatureComparisonStub {
     }
 }
 
-class SignatureComparisonTraitTest extends \PHPUnit_Framework_TestCase {
+class SignatureComparisonTraitTest extends TestCase {
     public function testDoMatch() {
         $description = "A test Description";
 

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\State;
 use TinCan\Group;
 
-class StateTest extends \PHPUnit_Framework_TestCase {
+class StateTest extends TestCase {
     public function testCanSetActivityWithArray() {
         $args = [
             'id' => COMMON_ACTIVITY_ID,

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -45,10 +45,8 @@ class StateTest extends TestCase {
     }
 
     public function testExceptionOnInvalidRegistrationUUID() {
-        $this->setExpectedException(
-            "InvalidArgumentException",
-            'arg1 must be a UUID'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('arg1 must be a UUID');
 
         $obj = new State();
         $obj->setRegistration('232....3.3..3./2/2/1m3m3m3');

--- a/tests/StatementBaseTest.php
+++ b/tests/StatementBaseTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\StatementBase;
 use TinCan\SubStatement;
 use TinCan\Verb;
@@ -26,7 +27,7 @@ use TinCan\Result;
 
 class StubStatementBase extends StatementBase {}
 
-class StatementBaseTest extends \PHPUnit_Framework_TestCase {
+class StatementBaseTest extends TestCase {
     public function testInstantiation() {
         $obj = new StubStatementBase();
     }

--- a/tests/StatementBaseTest.php
+++ b/tests/StatementBaseTest.php
@@ -61,8 +61,8 @@ class StatementBaseTest extends TestCase {
 
     public function testSetTargetInvalidArgumentException() {
         $badObjectType = 'imABadObjectType';
-        $this->setExpectedException(
-            "InvalidArgumentException",
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
             "arg1 must implement the StatementTargetInterface objectType not recognized:$badObjectType"
         );
         $obj = new StubStatementBase();
@@ -82,10 +82,8 @@ class StatementBaseTest extends TestCase {
     }
 
     public function testSetTimestampInvalidArgumentException() {
-        $this->setExpectedException(
-            "InvalidArgumentException",
-            'type of arg1 must be string or DateTime'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('type of arg1 must be string or DateTime');
 
         $obj = new StubStatementBase();
         $obj->setTimestamp(1);

--- a/tests/StatementRefTest.php
+++ b/tests/StatementRefTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\StatementRef;
 use TinCan\Util;
 
-class StatementRefTest extends \PHPUnit_Framework_TestCase {
+class StatementRefTest extends TestCase {
     public function testInstantiation() {
         $obj = new StatementRef();
         $this->assertInstanceOf('TinCan\StatementRef', $obj);

--- a/tests/StatementRefTest.php
+++ b/tests/StatementRefTest.php
@@ -42,10 +42,8 @@ class StatementRefTest extends TestCase {
     }
 
     public function testSetIdThrowsException() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'arg1 must be a UUID'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('arg1 must be a UUID');
         $obj = new StatementRef(['id' => 'foo']);
     }
 

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -602,8 +602,8 @@ class StatementTest extends TestCase {
         if (version_compare(PHP_VERSION, '7.1') >= 0) {
             $this->expectException('ArgumentCountError');
             $this->expectExceptionMessageRegExp(
-                '/Too few arguments to function ' . get_class($obj) . '::sign(), 0 passed in '
-                . __FILE__ . ' on line \d+ and at least 2 expected/'
+                '/Too few arguments to function ' . preg_quote(get_class($obj)) . '::sign\(\),'
+                . ' 0 passed in ' . preg_quote(__FILE__) . ' on line \d+ and at least 2 expected/'
             );
         } else {
             # PHPUnit class names changed in 6.0.0
@@ -628,8 +628,8 @@ class StatementTest extends TestCase {
         if (version_compare(PHP_VERSION, '7.1') >= 0) {
             $this->expectException('ArgumentCountError');
             $this->expectExceptionMessageRegExp(
-                '/Too few arguments to function ' . get_class($obj) . '::sign(), 1 passed in '
-                . __FILE__ . ' on line \d+ and at least 2 expected/'
+                '/Too few arguments to function ' . preg_quote(get_class($obj)) . '::sign\(\),'
+                . ' 1 passed in ' . preg_quote(__FILE__) . ' on line \d+ and at least 2 expected/'
             );
         } else {
             # PHPUnit class names changed in 6.0.0

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\Agent;
 use TinCan\Attachment;
@@ -28,7 +29,7 @@ use TinCan\Verb;
 use TinCan\Version;
 use Namshi\JOSE\JWS;
 
-class StatementTest extends \PHPUnit_Framework_TestCase {
+class StatementTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -48,17 +48,17 @@ class StatementTest extends TestCase {
     }
 
     public function testFromJSONInvalidNull() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Statement::fromJSON(null);
     }
 
     public function testFromJSONInvalidEmptyString() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Statement::fromJSON('');
     }
 
     public function testFromJSONInvalidMalformed() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Statement::fromJSON('{id:"some value"}');
     }
 
@@ -90,20 +90,16 @@ class StatementTest extends TestCase {
     }
 
     public function testSetId() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'arg1 must be a UUID "some invalid id"'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('arg1 must be a UUID "some invalid id"');
 
         $obj = new Statement();
         $obj->setId('some invalid id');
     }
 
     public function testSetStoredInvalidArgumentException() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'type of arg1 must be string or DateTime'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('type of arg1 must be string or DateTime');
 
         $obj = new Statement();
         $obj->setStored(1);
@@ -602,38 +598,66 @@ class StatementTest extends TestCase {
     public function testSignNoArgs() {
         $obj = new Statement();
 
-        $this->setExpectedException(
-            'PHPUnit_Framework_Error_Warning',
-            (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 0 given' : 'Missing argument 1')
-        );
+        # PHP 7.1 promoted "too few arguments" warning to an error exception
+        if (version_compare(PHP_VERSION, '7.1') >= 0) {
+            $this->expectException('ArgumentCountError');
+            $this->expectExceptionMessageRegExp(
+                '/Too few arguments to function ' . get_class($obj) . '::sign(), 0 passed in '
+                . __FILE__ . ' on line \d+ and at least 2 expected/'
+            );
+        } else {
+            # PHPUnit class names changed in 6.0.0
+            if (class_exists('PHPUnit_Framework_Error_Warning')) {
+                $exceptionClass =  'PHPUnit_Framework_Error_Warning';
+            } else {
+                $exceptionClass =  'PHPUnit\Framework\Error\Warning';
+            }
+            $this->expectException($exceptionClass);
+            $this->expectExceptionMessage(
+                (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 0 given' : 'Missing argument 1')
+            );
+        }
+
         $obj->sign();
     }
 
     public function testSignOneArg() {
         $obj = new Statement();
 
-        $this->setExpectedException(
-            'PHPUnit_Framework_Error_Warning',
-            (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 1 given' : 'Missing argument 2')
-        );
+        # PHP 7.1 promoted "too few arguments" warning to an error exception
+        if (version_compare(PHP_VERSION, '7.1') >= 0) {
+            $this->expectException('ArgumentCountError');
+            $this->expectExceptionMessageRegExp(
+                '/Too few arguments to function ' . get_class($obj) . '::sign(), 1 passed in '
+                . __FILE__ . ' on line \d+ and at least 2 expected/'
+            );
+        } else {
+            # PHPUnit class names changed in 6.0.0
+            if (class_exists('PHPUnit_Framework_Error_Warning')) {
+                $exceptionClass =  'PHPUnit_Framework_Error_Warning';
+            } else {
+                $exceptionClass =  'PHPUnit\Framework\Error\Warning';
+            }
+            $this->expectException($exceptionClass);
+            $this->expectExceptionMessage(
+                (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 1 given' : 'Missing argument 2')
+            );
+        }
+
         $obj->sign('test');
     }
 
     public function testSignNoActor() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'actor must be present in signed statement'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('actor must be present in signed statement');
 
         $obj = new Statement();
         $obj->sign('test', 'test');
     }
 
     public function testSignNoVerb() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'verb must be present in signed statement'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('verb must be present in signed statement');
 
         $obj = new Statement(
             [
@@ -644,10 +668,8 @@ class StatementTest extends TestCase {
     }
 
     public function testSignNoObject() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'object must be present in signed statement'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('object must be present in signed statement');
 
         $obj = new Statement(
             [
@@ -659,10 +681,8 @@ class StatementTest extends TestCase {
     }
 
     public function testSignInvalidAlgorithm() {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            "Invalid signing algorithm: 'not right'"
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage("Invalid signing algorithm: 'not right'");
 
         $obj = new Statement(
             [
@@ -677,8 +697,8 @@ class StatementTest extends TestCase {
     }
 
     public function testSignEmptyPassword() {
-        $this->setExpectedException(
-            'Exception',
+        $this->expectException('Exception');
+        $this->expectExceptionMessage(
             'Unable to get private key: error:0906A068:PEM routines:PEM_do_header:bad password read'
         );
 
@@ -695,10 +715,8 @@ class StatementTest extends TestCase {
     }
 
     public function testSignInvalidPassword() {
-        $this->setExpectedExceptionRegExp(
-            'Exception',
-            '/Unable to get private key: error:.*:bad decrypt/'
-        );
+        $this->expectException('Exception');
+        $this->expectExceptionMessageRegExp('/Unable to get private key: error:.*:bad decrypt/');
 
         $obj = new Statement(
             [
@@ -713,8 +731,14 @@ class StatementTest extends TestCase {
     }
 
     public function testSignInvalidX5cErrorToException() {
-        $this->setExpectedExceptionRegExp(
-            'PHPUnit_Framework_Error',
+        # PHPUnit class names changed in 6.0.0
+        if (class_exists('PHPUnit_Framework_Error')) {
+            $exceptionClass =  'PHPUnit_Framework_Error';
+        } else {
+            $exceptionClass =  'PHPUnit\Framework\Error\Error';
+        }
+        $this->expectException($exceptionClass);
+        $this->expectExceptionMessageRegExp(
             '/supplied parameter cannot be coerced into an X509 certificate!/'
         );
 
@@ -731,8 +755,8 @@ class StatementTest extends TestCase {
     }
 
     public function testSignInvalidX5cNoError() {
-        $this->setExpectedExceptionRegExp(
-            'Exception',
+        $this->expectException('Exception');
+        $this->expectExceptionMessageRegExp(
             '/Unable to read certificate for x5c inclusion: .*/'
         );
 
@@ -793,8 +817,14 @@ class StatementTest extends TestCase {
     }
 
     public function testVerifyInvalidX5cErrorToException() {
-        $this->setExpectedExceptionRegExp(
-            'PHPUnit_Framework_Error',
+        # PHPUnit class names changed in 6.0.0
+        if (class_exists('PHPUnit_Framework_Error')) {
+            $exceptionClass =  'PHPUnit_Framework_Error';
+        } else {
+            $exceptionClass =  'PHPUnit\Framework\Error\Error';
+        }
+        $this->expectException($exceptionClass);
+        $this->expectExceptionMessageRegExp(
             '/supplied parameter cannot be coerced into an X509 certificate!/'
         );
 

--- a/tests/StatementVariationsTest.php
+++ b/tests/StatementVariationsTest.php
@@ -17,12 +17,13 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\RemoteLRS;
 use TinCan\Statement;
 use TinCan\Util;
 
-class StatementVariationsTest extends \PHPUnit_Framework_TestCase {
+class StatementVariationsTest extends TestCase {
     static protected $lrss;
 
     static public function setUpBeforeClass() {

--- a/tests/SubStatementTest.php
+++ b/tests/SubStatementTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\Agent;
 use TinCan\Context;
@@ -25,7 +26,7 @@ use TinCan\SubStatement;
 use TinCan\Util;
 use TinCan\Verb;
 
-class SubStatementTest extends \PHPUnit_Framework_TestCase {
+class SubStatementTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Util;
 
-class UtilTest extends \PHPUnit_Framework_TestCase {
+class UtilTest extends TestCase {
     public function testGetUUID() {
         $result = Util::getUUID();
 

--- a/tests/VerbTest.php
+++ b/tests/VerbTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Verb;
 
-class VerbTest extends \PHPUnit_Framework_TestCase {
+class VerbTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     static private $DISPLAY;

--- a/tests/VerbTest.php
+++ b/tests/VerbTest.php
@@ -43,17 +43,17 @@ class VerbTest extends TestCase {
     }
 
     public function testFromJSONInvalidNull() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Verb::fromJSON(null);
     }
 
     public function testFromJSONInvalidEmptyString() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Verb::fromJSON('');
     }
 
     public function testFromJSONInvalidMalformed() {
-        $this->setExpectedException('TinCan\JSONParseErrorException');
+        $this->expectException('TinCan\JSONParseErrorException');
         $obj = Verb::fromJSON('{id:"some value"}');
     }
 

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Version;
 
-class VersionTest extends \PHPUnit_Framework_TestCase {
+class VersionTest extends TestCase {
     public function testStaticFactoryReturnsInstance() {
         $this->assertInstanceOf("TinCan\Version", Version::v101(), "factory returns instance");
     }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -65,10 +65,8 @@ class VersionTest extends TestCase {
 
     public function testInvalidArgumentExceptionIsThrown() {
         $number = '1.8.01';
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            "Invalid version [$number]"
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage("Invalid version [$number]");
         $version = Version::fromString($number);
     }
 }


### PR DESCRIPTION
This allows the tests to be run with PHPUnit >=5.4.0 <6.0.0 with PHP 5.6 and PHPUnit >=6.0.0 with PHP 7.