### PR TITLE
Fix testing PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "2.*",
-        "phpunit/phpunit": "@stable"
+        "phpunit/phpunit": "4.8.* || 5.7.*"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AboutTest.php
+++ b/tests/AboutTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\About;
 
-class AboutTest extends \PHPUnit_Framework_TestCase {
+class AboutTest extends TestCase {
     const VERSION_1 = '1.0.0';
 
     public function testInstantiation() {

--- a/tests/ActivityDefinitionTest.php
+++ b/tests/ActivityDefinitionTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\ActivityDefinition;
 
-class ActivityDefinitionTest extends \PHPUnit_Framework_TestCase {
+class ActivityDefinitionTest extends TestCase {
     const NAME = 'testName';
 
     private $emptyProperties = array(

--- a/tests/ActivityProfileTest.php
+++ b/tests/ActivityProfileTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\ActivityProfile;
 use TinCan\Activity;
 
-class ActivityProfileTest extends \PHPUnit_Framework_TestCase {
+class ActivityProfileTest extends TestCase {
     public function testSetActivity() {
         $profile = new ActivityProfile();
         $profile->setActivity(['id' => COMMON_ACTIVITY_ID]);

--- a/tests/ActivityTest.php
+++ b/tests/ActivityTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 
-class ActivityTest extends \PHPUnit_Framework_TestCase {
+class ActivityTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     static private $DEFINITION;

--- a/tests/AgentAccountTest.php
+++ b/tests/AgentAccountTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\AgentAccount;
 
-class AgentAccountTest extends \PHPUnit_Framework_TestCase {
+class AgentAccountTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     const HOMEPAGE = 'http://tincanapi.com';

--- a/tests/AgentProfileTest.php
+++ b/tests/AgentProfileTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\AgentProfile;
 use TinCan\Agent;
 use TinCan\Group;
 
-class AgentProfileTest extends \PHPUnit_Framework_TestCase {
+class AgentProfileTest extends TestCase {
     public function testSetAgent() {
         $profile = new AgentProfile();
         $profile->setAgent(['mbox' => COMMON_MBOX]);

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Agent;
 use TinCan\AgentAccount;
 
-class AgentTest extends \PHPUnit_Framework_TestCase {
+class AgentTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/AsVersionTraitTest.php
+++ b/tests/AsVersionTraitTest.php
@@ -17,7 +17,9 @@
 
 namespace TinCanTest;
 
-class AsVersionTraitTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AsVersionTraitTest extends TestCase
 {
     public function testTraitExists() {
         $this->assertTrue(trait_exists('TinCan\AsVersionTrait'));

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Attachment;
 use TinCan\Version;
 
-class AttachmentTest extends \PHPUnit_Framework_TestCase {
+class AttachmentTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     const USAGE_TYPE     = 'http://id.tincanapi.com/attachment/supporting_media';

--- a/tests/ContextActivitiesTest.php
+++ b/tests/ContextActivitiesTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\ContextActivities;
 
-class ContextActivitiesTest extends \PHPUnit_Framework_TestCase {
+class ContextActivitiesTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     static private $listProps = ['category', 'parent', 'grouping', 'other'];

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Agent;
 use TinCan\Context;
 use TinCan\ContextActivities;
@@ -25,7 +26,7 @@ use TinCan\Group;
 use TinCan\StatementRef;
 use TinCan\Util;
 
-class ContextTest extends \PHPUnit_Framework_TestCase {
+class ContextTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     private $emptyProperties = array(

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Document;
 
 class StubDocument extends Document {}
 
-class DocumentTest extends \PHPUnit_Framework_TestCase {
+class DocumentTest extends TestCase {
     public function testExceptionOnInvalidDateTime() {
         $this->setExpectedException(
             "InvalidArgumentException",

--- a/tests/ExtensionsTest.php
+++ b/tests/ExtensionsTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Extensions;
 
-class ExtensionsTest extends \PHPUnit_Framework_TestCase {
+class ExtensionsTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Agent;
 use TinCan\AgentAccount;
 use TinCan\Group;
 
-class GroupTest extends \PHPUnit_Framework_TestCase {
+class GroupTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/ISO8601Test.php
+++ b/tests/ISO8601Test.php
@@ -19,10 +19,11 @@ namespace TinCanTest;
 
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use TinCan\Statement;
 use TinCan\State;
 
-class ISO8601Test extends \PHPUnit_Framework_TestCase {
+class ISO8601Test extends TestCase {
     public function testProperties() {
         $str_datetime = '2014-12-15T19:16:05+00:00';
         $str_datetime_tz = '2014-12-15T13:16:05-06:00';

--- a/tests/JSONParseErrorExceptionTest.php
+++ b/tests/JSONParseErrorExceptionTest.php
@@ -15,9 +15,12 @@
     limitations under the License.
 */
 
+namespace TinCanTest;
+
+use PHPUnit\Framework\TestCase;
 use TinCan\JSONParseErrorException;
 
-class JSONParseErrorExceptionTest extends PHPUnit_Framework_TestCase
+class JSONParseErrorExceptionTest extends TestCase
 {
     private $exception;
     private $malformedValue  = '.....';

--- a/tests/LRSResponseTest.php
+++ b/tests/LRSResponseTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\LRSResponse;
 
-class LRSResponseTest extends \PHPUnit_Framework_TestCase {
+class LRSResponseTest extends TestCase {
     public function testInstantiation() {
         $obj = new LRSResponse(true, '', false);
         $this->assertTrue($obj->success);

--- a/tests/LanguageMapTest.php
+++ b/tests/LanguageMapTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\LanguageMap;
 
-class LanguageMapTest extends \PHPUnit_Framework_TestCase {
+class LanguageMapTest extends TestCase {
     const NAME = 'testName';
 
     public function testInstantiation() {

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Map;
 
 class StubMap extends Map {}
 
-class MapTest extends \PHPUnit_Framework_TestCase {
+class MapTest extends TestCase {
     public function testInstantiation() {
         $obj = new StubMap();
     }

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Person;
 
-class PersonTest extends \PHPUnit_Framework_TestCase {
+class PersonTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/RemoteLRSTest.php
+++ b/tests/RemoteLRSTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\Agent;
 use TinCan\Attachment;
@@ -28,7 +29,7 @@ use TinCan\Util;
 use TinCan\Verb;
 use TinCan\Version;
 
-class RemoteLRSTest extends \PHPUnit_Framework_TestCase {
+class RemoteLRSTest extends TestCase {
     static private $endpoint;
     static private $version;
     static private $username;

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -17,11 +17,12 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Extensions;
 use TinCan\Result;
 use TinCan\Score;
 
-class ResultTest extends \PHPUnit_Framework_TestCase {
+class ResultTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     private $emptyProperties = array(

--- a/tests/ScoreTest.php
+++ b/tests/ScoreTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Score;
 
-class ScoreTest extends \PHPUnit_Framework_TestCase {
+class ScoreTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     private $emptyProperties = array(

--- a/tests/SignatureComparisonTraitTest.php
+++ b/tests/SignatureComparisonTraitTest.php
@@ -17,6 +17,8 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
+
 class SignatureComparisonStub {
     use \TinCan\SignatureComparisonTrait;
 
@@ -25,7 +27,7 @@ class SignatureComparisonStub {
     }
 }
 
-class SignatureComparisonTraitTest extends \PHPUnit_Framework_TestCase {
+class SignatureComparisonTraitTest extends TestCase {
     public function testDoMatch() {
         $description = "A test Description";
 

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\State;
 use TinCan\Group;
 
-class StateTest extends \PHPUnit_Framework_TestCase {
+class StateTest extends TestCase {
     public function testCanSetActivityWithArray() {
         $args = [
             'id' => COMMON_ACTIVITY_ID,

--- a/tests/StatementBaseTest.php
+++ b/tests/StatementBaseTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\StatementBase;
 use TinCan\SubStatement;
 use TinCan\Verb;
@@ -26,7 +27,7 @@ use TinCan\Result;
 
 class StubStatementBase extends StatementBase {}
 
-class StatementBaseTest extends \PHPUnit_Framework_TestCase {
+class StatementBaseTest extends TestCase {
     public function testInstantiation() {
         $obj = new StubStatementBase();
     }

--- a/tests/StatementRefTest.php
+++ b/tests/StatementRefTest.php
@@ -17,10 +17,11 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\StatementRef;
 use TinCan\Util;
 
-class StatementRefTest extends \PHPUnit_Framework_TestCase {
+class StatementRefTest extends TestCase {
     public function testInstantiation() {
         $obj = new StatementRef();
         $this->assertInstanceOf('TinCan\StatementRef', $obj);

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -602,20 +602,38 @@ class StatementTest extends TestCase {
     public function testSignNoArgs() {
         $obj = new Statement();
 
-        $this->setExpectedException(
-            'PHPUnit_Framework_Error_Warning',
-            (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 0 given' : 'Missing argument 1')
-        );
+        # PHP 7.1 promoted "too few arguments" warning to an error exception
+        if (version_compare(PHP_VERSION, '7.1') >= 0) {
+            $this->setExpectedExceptionRegExp(
+                'ArgumentCountError',
+                '/Too few arguments to function ' . preg_quote(get_class($obj)) . '::sign\(\), 0 passed in '
+                . preg_quote(__FILE__) . ' on line \d+ and at least 2 expected/'
+            );
+        } else {
+            $this->setExpectedException(
+                'PHPUnit_Framework_Error_Warning',
+                (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 0 given' : 'Missing argument 1')
+            );
+        }
         $obj->sign();
     }
 
     public function testSignOneArg() {
         $obj = new Statement();
 
-        $this->setExpectedException(
-            'PHPUnit_Framework_Error_Warning',
-            (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 1 given' : 'Missing argument 2')
-        );
+        # PHP 7.1 promoted "too few arguments" warning to an error exception
+        if (version_compare(PHP_VERSION, '7.1') >= 0) {
+            $this->setExpectedExceptionRegExp(
+                'ArgumentCountError',
+                '/Too few arguments to function ' . preg_quote(get_class($obj)) . '::sign\(\), 1 passed in '
+                . preg_quote(__FILE__) . ' on line \d+ and at least 2 expected/'
+            );
+        } else {
+            $this->setExpectedException(
+                'PHPUnit_Framework_Error_Warning',
+                (getenv('TRAVIS_PHP_VERSION') == "hhvm" ? 'sign() expects at least 2 parameters, 1 given' : 'Missing argument 2')
+            );
+        }
         $obj->sign('test');
     }
 

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\Agent;
 use TinCan\Attachment;
@@ -28,7 +29,7 @@ use TinCan\Verb;
 use TinCan\Version;
 use Namshi\JOSE\JWS;
 
-class StatementTest extends \PHPUnit_Framework_TestCase {
+class StatementTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/StatementVariationsTest.php
+++ b/tests/StatementVariationsTest.php
@@ -17,12 +17,13 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\RemoteLRS;
 use TinCan\Statement;
 use TinCan\Util;
 
-class StatementVariationsTest extends \PHPUnit_Framework_TestCase {
+class StatementVariationsTest extends TestCase {
     static protected $lrss;
 
     static public function setUpBeforeClass() {

--- a/tests/SubStatementTest.php
+++ b/tests/SubStatementTest.php
@@ -17,6 +17,7 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Activity;
 use TinCan\Agent;
 use TinCan\Context;
@@ -25,7 +26,7 @@ use TinCan\SubStatement;
 use TinCan\Util;
 use TinCan\Verb;
 
-class SubStatementTest extends \PHPUnit_Framework_TestCase {
+class SubStatementTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     public function testInstantiation() {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Util;
 
-class UtilTest extends \PHPUnit_Framework_TestCase {
+class UtilTest extends TestCase {
     public function testGetUUID() {
         $result = Util::getUUID();
 

--- a/tests/VerbTest.php
+++ b/tests/VerbTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Verb;
 
-class VerbTest extends \PHPUnit_Framework_TestCase {
+class VerbTest extends TestCase {
     use TestCompareWithSignatureTrait;
 
     static private $DISPLAY;

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -17,9 +17,10 @@
 
 namespace TinCanTest;
 
+use PHPUnit\Framework\TestCase;
 use TinCan\Version;
 
-class VersionTest extends \PHPUnit_Framework_TestCase {
+class VersionTest extends TestCase {
     public function testStaticFactoryReturnsInstance() {
         $this->assertInstanceOf("TinCan\Version", Version::v101(), "factory returns instance");
     }


### PR DESCRIPTION
* Testing with PHP 7.0 was failing because PHPUnit 6.4 was used, which breaks compatibility with PHPUnit 4.8.* and 5.4.*.
* Updated tests for PHP 7.1 change to handling "too few arguments" error.