### PR TITLE
Allow for a verb/activity or its ID when querying for statements

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -510,7 +510,12 @@ class RemoteLRS implements LRSInterface
             ) as $k
         ) {
             if (isset($query[$k])) {
-                $result[$k] = $query[$k]->getId();
+                if (is_string($query[$k])) {
+                    $result[$k] = $query[$k];
+                }
+                else {
+                    $result[$k] = $query[$k]->getId();
+                }
             }
         }
         foreach (

--- a/tests/RemoteLRSTest.php
+++ b/tests/RemoteLRSTest.php
@@ -329,6 +329,24 @@ class RemoteLRSTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('TinCan\StatementsResult', $response->content);
     }
 
+    public function testQueryStatementsWithActivityId() {
+        $lrs = new RemoteLRS(self::$endpoint, self::$version, self::$username, self::$password);
+        $response = $lrs->queryStatements(['activity' => COMMON_ACTIVITY_ID]);
+
+        $this->assertInstanceOf('TinCan\LRSResponse', $response);
+        $this->assertTrue($response->success, 'success');
+        $this->assertInstanceOf('TinCan\StatementsResult', $response->content);
+    }
+
+    public function testQueryStatementsWithVerbId() {
+        $lrs = new RemoteLRS(self::$endpoint, self::$version, self::$username, self::$password);
+        $response = $lrs->queryStatements(['verb' => COMMON_VERB_ID]);
+
+        $this->assertInstanceOf('TinCan\LRSResponse', $response);
+        $this->assertTrue($response->success, 'success');
+        $this->assertInstanceOf('TinCan\StatementsResult', $response->content);
+    }
+
     public function testQueryStatementsWithAttachments() {
         $lrs = new RemoteLRS(self::$endpoint, self::$version, self::$username, self::$password);
         $response = $lrs->queryStatements(['limit' => 4, 'attachments' => true]);


### PR DESCRIPTION
This change lets you just specify an ID string instead of needing an entire verb or activity when querying for statements.

This addresses #98.