### PR TITLE
Fixes count with Object(stdClass).

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -46,7 +46,7 @@ abstract class Map implements VersionableInterface
     }
 
     public function isEmpty() {
-        return count($this->_map) === 0;
+        return count((array)($this->_map)) === 0;
     }
 
     public function __call($func, $args) {


### PR DESCRIPTION
On Php 7.3 you get this exception:

ErrorException(code: 0):
count():
Parameter must be an array or an object that implements Countable
at rusticisoftware/tincan/src/Map.php:49

This commit fixes it.