### PR TITLE
Fix deprecated use of "parent" in callables for php8.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
         "e-learning",
         "scorm"
     ],
+    "replace": {
+        "rusticisoftware/tincan": "*"
+    },
     "license": "Apache-2.0",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rusticisoftware/tincan",
+    "name": "opigno/tincan",
     "type": "library",
     "description": "Experience API (Tin Can API) Library",
     "homepage": "http://rusticisoftware.github.io/TinCanPHP/",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "issues": "https://github.com/RusticiSoftware/TinCanPHP/issues"
     },
     "require": {
-        "php": "~5.5 || ^7.0.3",
+        "php": "^7.0.3 || ^8",
         "ext-openssl": "*",
         "namshi/jose": "^7.2.1",
         "willdurand/negotiation": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "issues": "https://github.com/RusticiSoftware/TinCanPHP/issues"
     },
     "require": {
-        "php": "^7.0.3 || ^8",
+        "php": "~5.5 || ^7 || ^8",
         "ext-openssl": "*",
         "namshi/jose": "^7.2.1",
         "willdurand/negotiation": "^2.0"

--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -118,7 +118,7 @@ class RemoteLRS implements LRSInterface
             }
         }
         if (isset($options['params']) && count($options['params']) > 0) {
-            $url .= '?' . http_build_query($options['params'], null, '&', PHP_QUERY_RFC3986);
+            $url .= '?' . http_build_query($options['params'], '', '&', PHP_QUERY_RFC3986);
         }
 
         if (($method === 'PUT' || $method === 'POST') && isset($options['content'])) {

--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -137,7 +137,7 @@ class RemoteLRS implements LRSInterface
         // normal handling
         //
         set_error_handler(
-            function ($errno, $errstr, $errfile, $errline, array $errcontext) {
+            function ($errno, $errstr, $errfile, $errline) {
                 // "!== false" is intentional. strpos() can return 0, which is falsey, but returning
                 // 0 matches our "true" condition. Using strict equality to avoid that confusion.
                 if ($errno == E_NOTICE && strpos($errstr, 'Array to string conversion') !== false) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -72,7 +72,7 @@ class Util
         $microseconds = sprintf('%06d', ($time - floor($time)) * 1000000);
         $millseconds = round($microseconds, -3)/1000;
         $millsecondsStr = str_pad($millseconds, 3, '0', STR_PAD_LEFT);
-        $date = (new \DateTime(null, new \DateTimeZone("UTC")))->format('c');
+        $date = (new \DateTime('now', new \DateTimeZone("UTC")))->format('c');
 
         $position = strrpos($date, '+');
         $date = substr($date,0,$position).'.'.$millsecondsStr.substr($date,$position);


### PR DESCRIPTION
Fix deprecated use of "parent" in callables for php8.3.